### PR TITLE
64-channel headstage acquisition devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Packages
 *.user
 *.exe
 *.exe.settings
+*.exe.WebView2

--- a/Bonsai/Bonsai.config
+++ b/Bonsai/Bonsai.config
@@ -27,6 +27,7 @@
     <Package id="ZedGraph" version="5.1.7" />
   </Packages>
   <AssemblyReferences>
+    <AssemblyReference assemblyName="Bonsai" />
     <AssemblyReference assemblyName="Bonsai.Core" />
     <AssemblyReference assemblyName="Bonsai.Design" />
     <AssemblyReference assemblyName="Bonsai.Design.Visualizers" />
@@ -39,6 +40,7 @@
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
   </AssemblyReferences>
   <AssemblyLocations>
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.0\lib\net48\Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.0\lib\net462\Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll" />

--- a/OpenEphys.Onix/NuGet.config
+++ b/OpenEphys.Onix/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
+    <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
+    <add key="Boost Packages" value="https://www.myget.org/F/bonsai-boost/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/OpenEphys.Onix/OpenEphys.Onix/BitHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BitHelper.cs
@@ -1,10 +1,17 @@
-﻿namespace OpenEphys.Onix
+﻿using System.Net;
+
+namespace OpenEphys.Onix
 {
     static class BitHelper
     {
         internal static uint Replace(uint value, uint mask, uint bits)
         {
             return (value & ~mask) | (bits & mask);
+        }
+
+        internal static ulong SwapEndian(ulong value)
+        {
+            return unchecked((ulong)IPAddress.NetworkToHostOrder((long)value));
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/BitHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BitHelper.cs
@@ -1,0 +1,10 @@
+﻿namespace OpenEphys.Onix
+{
+    static class BitHelper
+    {
+        internal static uint Replace(uint value, uint mask, uint bits)
+        {
+            return (value & ~mask) | (bits & mask);
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class Bno055Data : Source<Bno055DataFrame>
+    {
+        [TypeConverter(typeof(Bno055.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<Bno055DataFrame> Generate()
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var device = deviceInfo.GetDevice(typeof(Bno055));
+                    return deviceInfo.Context.FrameReceived
+                        .Where(frame => frame.DeviceAddress == device.Address)
+                        .Select(frame => new Bno055DataFrame(frame));
+                }));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -10,10 +10,13 @@ namespace OpenEphys.Onix
         {
             Clock = frame.Clock;
             var payload = (Bno055Payload*)frame.Data.ToPointer();
+            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder(payload->HubClock));
             Payload = *payload;
         }
 
         public ulong Clock { get; }
+
+        public ulong HubClock { get; }
 
         public Bno055Payload Payload { get; }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace OpenEphys.Onix
@@ -10,34 +11,53 @@ namespace OpenEphys.Onix
         {
             Clock = frame.Clock;
             var payload = (Bno055Payload*)frame.Data.ToPointer();
-            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder(payload->HubClock));
-            Payload = *payload;
+            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder((long)payload->HubClock));
+            EulerAngle = new Vector3(
+                y: Bno055.EulerAngleScale * payload->EulerAngle[0],  // yaw
+                z: Bno055.EulerAngleScale * payload->EulerAngle[1],  // roll
+                x: Bno055.EulerAngleScale * payload->EulerAngle[2]); // pitch
+            Quaternion = new Quaternion(
+                w: Bno055.QuaternionScale * payload->Quaternion[0],
+                x: Bno055.QuaternionScale * payload->Quaternion[1],
+                y: Bno055.QuaternionScale * payload->Quaternion[2],
+                z: Bno055.QuaternionScale * payload->Quaternion[3]);
+            Acceleration = new Vector3(
+                x: Bno055.AccelerationScale * payload->Acceleration[0],
+                y: Bno055.AccelerationScale * payload->Acceleration[1],
+                z: Bno055.AccelerationScale * payload->Acceleration[2]);
+            Gravity = new Vector3(
+                x: Bno055.AccelerationScale * payload->Gravity[0],
+                y: Bno055.AccelerationScale * payload->Gravity[1],
+                z: Bno055.AccelerationScale * payload->Gravity[2]);
+            Temperature = payload->Temperature;
+            Calibration = payload->Calibration;
         }
 
         public ulong Clock { get; }
 
         public ulong HubClock { get; }
 
-        public Bno055Payload Payload { get; }
+        public Vector3 EulerAngle { get; }
+
+        public Quaternion Quaternion { get; }
+
+        public Vector3 Acceleration { get; }
+
+        public Vector3 Gravity { get; }
+
+        public int Temperature { get; }
+
+        public Bno055CalibrationFlags Calibration { get; }
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Bno055Payload
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct Bno055Payload
     {
-        public long HubClock;
-        public short EulerAngleYaw;
-        public short EulerAngleRoll;
-        public short EulerAnglePitch;
-        public short QuaternionW;
-        public short QuaternionX;
-        public short QuaternionY;
-        public short QuaternionZ;
-        public short AccelerationX;
-        public short AccelerationY;
-        public short AccelerationZ;
-        public short GravityX;
-        public short GravityY;
-        public short GravityZ;
+        public ulong HubClock;
+        public fixed short EulerAngle[3];
+        public fixed short Quaternion[4];
+        public fixed short Acceleration[3];
+        public fixed short Gravity[3];
         public byte Temperature;
         public Bno055CalibrationFlags Calibration;
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Net;
+using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix
+{
+    public class Bno055DataFrame
+    {
+        public unsafe Bno055DataFrame(oni.Frame frame)
+        {
+            Clock = frame.Clock;
+            var payload = (Bno055Payload*)frame.Data.ToPointer();
+            Payload = *payload;
+        }
+
+        public ulong Clock { get; }
+
+        public Bno055Payload Payload { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Bno055Payload
+    {
+        public long HubClock;
+        public short EulerAngleYaw;
+        public short EulerAngleRoll;
+        public short EulerAnglePitch;
+        public short QuaternionW;
+        public short QuaternionX;
+        public short QuaternionY;
+        public short QuaternionZ;
+        public short AccelerationX;
+        public short AccelerationY;
+        public short AccelerationZ;
+        public short GravityX;
+        public short GravityY;
+        public short GravityZ;
+        public byte Temperature;
+        public Bno055CalibrationFlags Calibration;
+    }
+
+    [Flags]
+    public enum Bno055CalibrationFlags : byte
+    {
+        None = 0,
+        System = 0x3,
+        Gyroscope = 0xC,
+        Accelerometer = 0x30,
+        Magnetometer = 0xC0
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
@@ -11,7 +10,7 @@ namespace OpenEphys.Onix
         {
             Clock = frame.Clock;
             var payload = (Bno055Payload*)frame.Data.ToPointer();
-            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder((long)payload->HubClock));
+            HubClock = BitHelper.SwapEndian(payload->HubClock);
             EulerAngle = new Vector3(
                 y: Bno055.EulerAngleScale * payload->EulerAngle[0],  // yaw
                 z: Bno055.EulerAngleScale * payload->EulerAngle[1],  // roll

--- a/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
@@ -1,0 +1,25 @@
+﻿using OpenCV.Net;
+
+namespace OpenEphys.Onix
+{
+    static class BufferHelper
+    {
+        public static Mat CopyBuffer<TBuffer>(
+            TBuffer[] buffer,
+            int sampleCount,
+            int channelCount,
+            Depth depth)
+            where TBuffer : unmanaged
+        {
+            using var bufferHeader = Mat.CreateMatHeader(
+                buffer,
+                sampleCount,
+                channelCount,
+                depth,
+                channels: 1);
+            var amplifierData = new Mat(bufferHeader.Cols, bufferHeader.Rows, bufferHeader.Depth, 1);
+            CV.Transpose(bufferHeader, amplifierData);
+            return amplifierData;
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
@@ -26,7 +26,7 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 var device = context.GetDevice(deviceAddress, Bno055.ID);
-                context.WriteRegister(deviceAddress, Bno055.ENABLE, 1);
+                context.WriteRegister(deviceAddress, Bno055.ENABLE, Enable ? 1u : 0);
 
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
                 var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Reactive.Disposables;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenEphys.Onix
 {
@@ -39,6 +34,12 @@ namespace OpenEphys.Onix
     {
         public const int ID = 9;
 
+        // constants
+        public const float EulerAngleScale = 1f / 16; // 1 degree = 16 LSB
+        public const float QuaternionScale = 1f / (1 << 14); // 1 = 2^14 LSB
+        public const float AccelerationScale = 1f / 100; // 1m / s^2 = 100 LSB
+
+        // managed registers
         public const uint ENABLE = 0x10000;  // Enable the heartbeat
 
         internal class NameConverter : DeviceNameConverter

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
@@ -40,7 +40,7 @@ namespace OpenEphys.Onix
         public const float AccelerationScale = 1f / 100; // 1m / s^2 = 100 LSB
 
         // managed registers
-        public const uint ENABLE = 0x10000;  // Enable the heartbeat
+        public const uint ENABLE = 0x0; // Enable or disable the data output stream
 
         internal class NameConverter : DeviceNameConverter
         {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Reactive.Disposables;
+using System.Threading;
 
 namespace OpenEphys.Onix
 {
@@ -38,8 +39,11 @@ namespace OpenEphys.Onix
                 var maxVoltage = (uint)(MaxVoltage * 10);
                 for (uint voltage = minVoltage; voltage <= maxVoltage; voltage += 2)
                 {
+                    const int WaitUntilVoltageSettles = 200;
                     context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, 0);
+                    Thread.Sleep(WaitUntilVoltageSettles);
                     context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, voltage);
+                    Thread.Sleep(WaitUntilVoltageSettles);
 
                     var linkState = context.ReadRegister(deviceAddress, FmcLinkController.LINKSTATE);
                     if ((linkState & FmcLinkController.LINKSTATE_SL) != 0)
@@ -52,6 +56,7 @@ namespace OpenEphys.Onix
 
                 if (!hasLock)
                 {
+                    context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, 0);
                     throw new InvalidOperationException("Unable to get SERDES lock on FMC link controller.");
                 }
             }).ConfigureDevice(context =>

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -4,12 +4,12 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class Headstage64 : HubDeviceFactory, INamedElement
+    public class ConfigureHeadstage64 : HubDeviceFactory, INamedElement
     {
         PortName port;
         readonly ConfigureFmcLinkController LinkController = new();
 
-        public Headstage64()
+        public ConfigureHeadstage64()
         {
             Port = PortName.PortA;
             LinkController.Passthrough = false;

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix
 {
     public class ConfigureHeadstage64 : HubDeviceFactory, INamedElement
     {
+        string name;
         PortName port;
         readonly ConfigureFmcLinkController LinkController = new();
 
@@ -17,7 +18,15 @@ namespace OpenEphys.Onix
             LinkController.MaxVoltage = 7.0;
         }
 
-        public string Name { get; set; }
+        public string Name
+        {
+            get { return name; }
+            set
+            {
+                name = value;
+                UpdateDeviceNames(name);
+            }
+        }
 
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
@@ -37,15 +46,20 @@ namespace OpenEphys.Onix
             set
             {
                 port = value;
-                LinkController.DeviceAddress = (uint)port;
-                Rhd2164.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.Rhd2164" : null;
-                Bno055.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.Bno055" : null;
-                TS4231.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.TS4231" : null;
                 var offset = (uint)port << 8;
+                LinkController.DeviceAddress = (uint)port;
                 Rhd2164.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
                 TS4231.DeviceAddress = offset + 2;
+                UpdateDeviceNames(Name);
             }
+        }
+
+        private void UpdateDeviceNames(string name)
+        {
+            Rhd2164.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.Rhd2164" : null;
+            Bno055.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.Bno055" : null;
+            TS4231.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.TS4231" : null;
         }
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -16,12 +16,13 @@ namespace OpenEphys.Onix
 
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
+            var enable = Enable;
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
                 var device = context.GetDevice(deviceAddress, Rhd2164.ID);
-                context.WriteRegister(deviceAddress, Rhd2164.ENABLE, 1);
+                context.WriteRegister(deviceAddress, Rhd2164.ENABLE, enable ? 1u : 0);
 
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
                 var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -93,6 +93,10 @@ namespace OpenEphys.Onix
     {
         public const int ID = 3;
 
+        // constants
+        public const int AmplifierChannelCount = 64;
+        public const int AuxChannelCount = 3;
+
         // managed registers
         public const uint ENABLE = 0x8000;
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -41,15 +41,21 @@ namespace OpenEphys.Onix
                 // https://intantech.com/files/Intan_RHD2000_series_datasheet.pdf
                 var device = context.GetDevice(deviceAddress, Rhd2164.ID);
 
-                var format = 0;
+                var format = context.ReadRegister(deviceAddress, Rhd2164.FORMAT);
                 var amplifierDataFormat = AmplifierDataFormat;
-                format |= (int)amplifierDataFormat << 6;
+                format &= ~(1u << 6);
+                format |= (uint)amplifierDataFormat << 6;
 
                 var dspCutoff = DspCutoff;
-                if (dspCutoff != Rhd2164DspCutoff.Off)
+                if (dspCutoff == Rhd2164DspCutoff.Off)
+                {
+                    format &= ~(1u << 4);
+                }
+                else
                 {
                     format |= 1 << 4;
-                    format |= (int)dspCutoff;
+                    format &= ~0xFu;
+                    format |= (uint)dspCutoff;
                 }
 
                 var highCutoff = Rhd2164Config.AnalogHighCutoffToRegisters[AnalogHighCutoff];
@@ -66,7 +72,7 @@ namespace OpenEphys.Onix
                 context.WriteRegister(deviceAddress, Rhd2164.BW3, (uint)bw3);
                 context.WriteRegister(deviceAddress, Rhd2164.BW4, (uint)bw4);
                 context.WriteRegister(deviceAddress, Rhd2164.BW5, (uint)bw5);
-                context.WriteRegister(deviceAddress, Rhd2164.FORMAT, (uint)format);
+                context.WriteRegister(deviceAddress, Rhd2164.FORMAT, format);
                 context.WriteRegister(deviceAddress, Rhd2164.ENABLE, enable ? 1u : 0);
 
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -20,7 +20,7 @@ namespace OpenEphys.Onix
 
         [Category(ConfigurationCategory)]
         [Description("Specifies the cutoff frequency for the DSP high-pass filter used for amplifier offset removal.")]
-        public Rhd2164DspCutoff DspCutoff { get; set; }
+        public Rhd2164DspCutoff DspCutoff { get; set; } = Rhd2164DspCutoff.Dsp146mHz;
 
         [Category(ConfigurationCategory)]
         [Description("Specifies the lower cutoff frequency of the pre-ADC amplifiers.")]

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -14,6 +14,12 @@ namespace OpenEphys.Onix
         [Description("Specifies whether the RHD2164 device is enabled.")]
         public bool Enable { get; set; } = true;
 
+        [Category(ConfigurationCategory)]
+        public Rhd2164AmplifierDataFormat AmplifierDataFormat { get; set; }
+
+        [Category(ConfigurationCategory)]
+        public Rhd2164DspCutoff DspCutoff { get; set; }
+
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
             var enable = Enable;
@@ -21,8 +27,23 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
+                // config register format following RHD2164 datasheet
+                // https://intantech.com/files/Intan_RHD2000_series_datasheet.pdf
                 var device = context.GetDevice(deviceAddress, Rhd2164.ID);
                 context.WriteRegister(deviceAddress, Rhd2164.ENABLE, enable ? 1u : 0);
+
+                var format = 0;
+                var amplifierDataFormat = AmplifierDataFormat;
+                format |= (int)amplifierDataFormat << 6;
+
+                var dspCutoff = DspCutoff;
+                if (dspCutoff != Rhd2164DspCutoff.Off)
+                {
+                    format |= 1 << 4;
+                    format |= (int)dspCutoff;
+                }
+
+                context.WriteRegister(deviceAddress, Rhd2164.FORMAT, (uint)format);
 
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
                 var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
@@ -36,6 +57,30 @@ namespace OpenEphys.Onix
         public const int ID = 3;
 
         public const uint ENABLE = 0x10000;  // Enable the heartbeat
+
+        // unmanaged registers
+        public const uint ADCCONF = 0x00; // ADC Configuration and Amplifier Fast Settle
+        public const uint ADCBUFF = 0x01; // Supply Sensor and ADC Buffer Bias Current
+        public const uint MUXBIAS = 0x02; // MUX Bias Current
+        public const uint MUXLOAD = 0x03; // MUX Load, Temperature Sensor, and Auxiliary Digital Output
+        public const uint FORMAT = 0x04; // ADC Output Format and DSP Offset Removal
+        public const uint ZCHECK = 0x05; // Impedance Check Control
+        public const uint ZDAC = 0x06; // Impedance Check DAC
+        public const uint ZSELECT = 0x07; // Impedance Check Amplifier Select
+        public const uint BW0 = 0x08; // On-Chip Amplifier Bandwidth Select 0
+        public const uint BW1 = 0x09; // On-Chip Amplifier Bandwidth Select 1
+        public const uint BW2 = 0x0a; // On-Chip Amplifier Bandwidth Select 2
+        public const uint BW3 = 0x0b; // On-Chip Amplifier Bandwidth Select 3
+        public const uint BW4 = 0x0c; // On-Chip Amplifier Bandwidth Select 4
+        public const uint BW5 = 0x0e; // On-Chip Amplifier Bandwidth Select 5
+        public const uint PWR0 = 0x0f; // Individual Amplifier Power 0
+        public const uint PWR1 = 0x10; // Individual Amplifier Power 1
+        public const uint PWR2 = 0x11; // Individual Amplifier Power 2
+        public const uint PWR3 = 0x12; // Individual Amplifier Power 3
+        public const uint PWR4 = 0x13; // Individual Amplifier Power 4
+        public const uint PWR5 = 0x14; // Individual Amplifier Power 5
+        public const uint PWR6 = 0x15; // Individual Amplifier Power 6
+        public const uint PWR7 = 0x16; // Individual Amplifier Power 7
 
         internal class NameConverter : DeviceNameConverter
         {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -114,15 +114,15 @@ namespace OpenEphys.Onix
         public const uint BW2 = 0x0a; // On-Chip Amplifier Bandwidth Select 2
         public const uint BW3 = 0x0b; // On-Chip Amplifier Bandwidth Select 3
         public const uint BW4 = 0x0c; // On-Chip Amplifier Bandwidth Select 4
-        public const uint BW5 = 0x0e; // On-Chip Amplifier Bandwidth Select 5
-        public const uint PWR0 = 0x0f; // Individual Amplifier Power 0
-        public const uint PWR1 = 0x10; // Individual Amplifier Power 1
-        public const uint PWR2 = 0x11; // Individual Amplifier Power 2
-        public const uint PWR3 = 0x12; // Individual Amplifier Power 3
-        public const uint PWR4 = 0x13; // Individual Amplifier Power 4
-        public const uint PWR5 = 0x14; // Individual Amplifier Power 5
-        public const uint PWR6 = 0x15; // Individual Amplifier Power 6
-        public const uint PWR7 = 0x16; // Individual Amplifier Power 7
+        public const uint BW5 = 0x0d; // On-Chip Amplifier Bandwidth Select 5
+        public const uint PWR0 = 0x0e; // Individual Amplifier Power 0
+        public const uint PWR1 = 0x0f; // Individual Amplifier Power 1
+        public const uint PWR2 = 0x10; // Individual Amplifier Power 2
+        public const uint PWR3 = 0x11; // Individual Amplifier Power 3
+        public const uint PWR4 = 0x12; // Individual Amplifier Power 4
+        public const uint PWR5 = 0x13; // Individual Amplifier Power 5
+        public const uint PWR6 = 0x14; // Individual Amplifier Power 6
+        public const uint PWR7 = 0x15; // Individual Amplifier Power 7
 
         internal class NameConverter : DeviceNameConverter
         {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -93,7 +93,8 @@ namespace OpenEphys.Onix
     {
         public const int ID = 3;
 
-        public const uint ENABLE = 0x10000;  // Enable the heartbeat
+        // managed registers
+        public const uint ENABLE = 0x8000;
 
         // unmanaged registers
         public const uint ADCCONF = 0x00; // ADC Configuration and Amplifier Fast Settle

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -98,7 +98,7 @@ namespace OpenEphys.Onix
         public const int AuxChannelCount = 3;
 
         // managed registers
-        public const uint ENABLE = 0x8000;
+        public const uint ENABLE = 0x8000; // Enable or disable the data output stream
 
         // unmanaged registers
         public const uint ADCCONF = 0x00; // ADC Configuration and Amplifier Fast Settle

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -60,18 +60,25 @@ namespace OpenEphys.Onix
 
                 var highCutoff = Rhd2164Config.AnalogHighCutoffToRegisters[AnalogHighCutoff];
                 var lowCutoff = Rhd2164Config.AnalogLowCutoffToRegisters[AnalogLowCutoff];
-                var bw0 = highCutoff[0] & 0b00111111;
-                var bw1 = highCutoff[1] & 0b00011111;
-                var bw2 = highCutoff[2] & 0b00111111;
-                var bw3 = highCutoff[3] & 0b00011111;
-                var bw4 = lowCutoff[0] & 0b01111111;
-                var bw5 = (lowCutoff[2] << 6) & 0b01000000 | lowCutoff[1] & 0b00111111;
-                context.WriteRegister(deviceAddress, Rhd2164.BW0, (uint)bw0);
-                context.WriteRegister(deviceAddress, Rhd2164.BW1, (uint)bw1);
-                context.WriteRegister(deviceAddress, Rhd2164.BW2, (uint)bw2);
-                context.WriteRegister(deviceAddress, Rhd2164.BW3, (uint)bw3);
-                context.WriteRegister(deviceAddress, Rhd2164.BW4, (uint)bw4);
-                context.WriteRegister(deviceAddress, Rhd2164.BW5, (uint)bw5);
+                var bw0 = context.ReadRegister(deviceAddress, Rhd2164.BW0);
+                var bw1 = context.ReadRegister(deviceAddress, Rhd2164.BW1);
+                var bw2 = context.ReadRegister(deviceAddress, Rhd2164.BW2);
+                var bw3 = context.ReadRegister(deviceAddress, Rhd2164.BW3);
+                var bw4 = context.ReadRegister(deviceAddress, Rhd2164.BW4);
+                var bw5 = context.ReadRegister(deviceAddress, Rhd2164.BW5);
+                bw0 = BitHelper.Replace(bw0, 0b00111111, (uint)highCutoff[0]);
+                bw1 = BitHelper.Replace(bw1, 0b00011111, (uint)highCutoff[1]);
+                bw2 = BitHelper.Replace(bw2, 0b00111111, (uint)highCutoff[2]);
+                bw3 = BitHelper.Replace(bw3, 0b00011111, (uint)highCutoff[3]);
+                bw4 = BitHelper.Replace(bw4, 0b01111111, (uint)lowCutoff[0]);
+                bw5 = BitHelper.Replace(bw5, 0b01111111, ((uint)lowCutoff[2] << 6) & 0b01000000 |
+                                                          (uint)lowCutoff[1] & 0b00111111);
+                context.WriteRegister(deviceAddress, Rhd2164.BW0, bw0);
+                context.WriteRegister(deviceAddress, Rhd2164.BW1, bw1);
+                context.WriteRegister(deviceAddress, Rhd2164.BW2, bw2);
+                context.WriteRegister(deviceAddress, Rhd2164.BW3, bw3);
+                context.WriteRegister(deviceAddress, Rhd2164.BW4, bw4);
+                context.WriteRegister(deviceAddress, Rhd2164.BW5, bw5);
                 context.WriteRegister(deviceAddress, Rhd2164.FORMAT, format);
                 context.WriteRegister(deviceAddress, Rhd2164.ENABLE, enable ? 1u : 0);
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -24,11 +24,11 @@ namespace OpenEphys.Onix
 
         [Category(ConfigurationCategory)]
         [Description("Specifies the lower cutoff frequency of the pre-ADC amplifiers.")]
-        public Rhd2164AnalogLowCutoff AnalogLowCutoff { get; set; }
+        public Rhd2164AnalogLowCutoff AnalogLowCutoff { get; set; } = Rhd2164AnalogLowCutoff.Low100mHz;
 
         [Category(ConfigurationCategory)]
         [Description("Specifies the upper cutoff frequency of the pre-ADC amplifiers.")]
-        public Rhd2164AnalogHighCutoff AnalogHighCutoff { get; set; }
+        public Rhd2164AnalogHighCutoff AnalogHighCutoff { get; set; } = Rhd2164AnalogHighCutoff.High10000Hz;
 
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureTS4231 : SingleDeviceFactory
+    {
+        public ConfigureTS4231()
+            : base(typeof(TS4231))
+        {
+        }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies whether the TS4231 device is enabled.")]
+        public bool Enable { get; set; } = true;
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice(context =>
+            {
+                var device = context.GetDevice(deviceAddress, TS4231.ID);
+                context.WriteRegister(deviceAddress, TS4231.ENABLE, Enable ? 1u : 0);
+
+                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
+                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
+                return disposable;
+            });
+        }
+    }
+
+    static class TS4231
+    {
+        public const int ID = 25;
+
+        // managed registers
+        public const uint ENABLE = 0x0; // Enable or disable the data output stream
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(TS4231))
+            {
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class Headstage64 : HubDeviceFactory
+    public class Headstage64 : HubDeviceFactory, INamedElement
     {
         PortName port;
         readonly ConfigureFmcLinkController LinkController = new();
@@ -16,9 +17,13 @@ namespace OpenEphys.Onix
             LinkController.MaxVoltage = 7.0;
         }
 
+        public string Name { get; set; }
+
+        [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureRhd2164 Rhd2164 { get; set; } = new();
 
+        [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureBno055 Bno055 { get; set; } = new();
 
@@ -29,6 +34,8 @@ namespace OpenEphys.Onix
             {
                 port = value;
                 LinkController.DeviceAddress = (uint)port;
+                Rhd2164.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.Rhd2164" : null;
+                Bno055.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.Bno055" : null;
                 Rhd2164.DeviceAddress = ((uint)port << 8) + 0;
                 Bno055.DeviceAddress = ((uint)port << 8) + 1;
             }

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
@@ -12,8 +12,8 @@ namespace OpenEphys.Onix
         {
             Port = PortName.PortA;
             LinkController.Passthrough = false;
-            LinkController.MinVoltage = 3.3;
-            LinkController.MaxVoltage = 8.0;
+            LinkController.MinVoltage = 5.0;
+            LinkController.MaxVoltage = 7.0;
         }
 
         [TypeConverter(typeof(HubDeviceConverter))]

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
@@ -11,6 +11,9 @@ namespace OpenEphys.Onix
         public Headstage64()
         {
             Port = PortName.PortA;
+            LinkController.Passthrough = false;
+            LinkController.MinVoltage = 3.3;
+            LinkController.MaxVoltage = 8.0;
         }
 
         [TypeConverter(typeof(HubDeviceConverter))]

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64.cs
@@ -27,6 +27,10 @@ namespace OpenEphys.Onix
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureBno055 Bno055 { get; set; } = new();
 
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureTS4231 TS4231 { get; set; } = new() { Enable = false };
+
         public PortName Port
         {
             get { return port; }
@@ -36,8 +40,11 @@ namespace OpenEphys.Onix
                 LinkController.DeviceAddress = (uint)port;
                 Rhd2164.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.Rhd2164" : null;
                 Bno055.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.Bno055" : null;
-                Rhd2164.DeviceAddress = ((uint)port << 8) + 0;
-                Bno055.DeviceAddress = ((uint)port << 8) + 1;
+                TS4231.DeviceName = !string.IsNullOrEmpty(Name) ? $"{Name}.TS4231" : null;
+                var offset = (uint)port << 8;
+                Rhd2164.DeviceAddress = offset + 0;
+                Bno055.DeviceAddress = offset + 1;
+                TS4231.DeviceAddress = offset + 2;
             }
         }
 
@@ -46,6 +53,7 @@ namespace OpenEphys.Onix
             yield return LinkController;
             yield return Rhd2164;
             yield return Bno055;
+            yield return TS4231;
         }
     }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/MatHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/MatHelper.cs
@@ -7,6 +7,12 @@ namespace OpenEphys.Onix
 {
     static class MatHelper
     {
+        public static unsafe Mat GetMatData(int rows, int cols, Depth depth, void* data)
+        {
+            var mat = new Mat(rows, cols, depth, channels: 1, (IntPtr)data);
+            return mat.Clone();
+        }
+
         public static uint GetElementSize(Depth depth)
         {
             return depth switch

--- a/OpenEphys.Onix/OpenEphys.Onix/OpenEphys.Onix.csproj
+++ b/OpenEphys.Onix/OpenEphys.Onix/OpenEphys.Onix.csproj
@@ -12,6 +12,7 @@
     <PackageOutputPath></PackageOutputPath>
     <PackageTags>Bonsai Rx Open Ephys Onix</PackageTags>
     <TargetFramework>net472</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>
     <Version>0.1.0</Version>

--- a/OpenEphys.Onix/OpenEphys.Onix/Properties/launchSettings.json
+++ b/OpenEphys.Onix/OpenEphys.Onix/Properties/launchSettings.json
@@ -3,7 +3,8 @@
     "Bonsai": {
       "commandName": "Executable",
       "executablePath": "$(SolutionDir)..\\Bonsai\\Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "commandLineArgs": "--lib:$(TargetDir).",
+      "nativeDebugging": true
     }
   }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Config.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Config.cs
@@ -1,5 +1,114 @@
-﻿namespace OpenEphys.Onix
+﻿using System.Collections.Generic;
+
+namespace OpenEphys.Onix
 {
+    public static class Rhd2164Config
+    {
+        public static readonly IReadOnlyDictionary<Rhd2164AnalogLowCutoff, IReadOnlyList<int>> AnalogLowCutoffToRegisters =
+            new Dictionary<Rhd2164AnalogLowCutoff, IReadOnlyList<int>>()
+        {
+            { Rhd2164AnalogLowCutoff.Low500Hz, new[] { 13, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low300Hz, new[] { 15, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low250Hz, new[] { 17, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low200Hz, new[] { 18, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low150Hz, new[] { 21, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low100Hz, new[] { 25, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low75Hz, new[] { 28, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low50Hz, new[] { 34, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low30Hz, new[] { 44, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low25Hz, new[] { 48, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low20Hz, new[] { 54, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low15Hz, new[] { 62, 0, 0 } },
+            { Rhd2164AnalogLowCutoff.Low10Hz, new[] { 5, 1, 0 } },
+            { Rhd2164AnalogLowCutoff.Low7500mHz, new[] { 18, 1, 0 } },
+            { Rhd2164AnalogLowCutoff.Low5000mHz, new[] { 40, 1, 0 } },
+            { Rhd2164AnalogLowCutoff.Low3090mHz, new[] { 20, 2, 0 } },
+            { Rhd2164AnalogLowCutoff.Low2500mHz, new[] { 42, 2, 0 } },
+            { Rhd2164AnalogLowCutoff.Low2000mHz, new[] { 8, 3, 0 } },
+            { Rhd2164AnalogLowCutoff.Low1500mHz, new[] { 9, 4, 0 } },
+            { Rhd2164AnalogLowCutoff.Low1000mHz, new[] { 44, 6, 0 } },
+            { Rhd2164AnalogLowCutoff.Low750mHz, new[] { 49, 9, 0 } },
+            { Rhd2164AnalogLowCutoff.Low500mHz, new[] { 35, 17, 0 } },
+            { Rhd2164AnalogLowCutoff.Low300mHz, new[] { 1, 40, 0 } },
+            { Rhd2164AnalogLowCutoff.Low250mHz, new[] { 56, 54, 0 } },
+            { Rhd2164AnalogLowCutoff.Low100mHz, new[] { 16, 60, 1 } },
+        };
+
+        public static readonly IReadOnlyDictionary<Rhd2164AnalogHighCutoff, IReadOnlyList<int>> AnalogHighCutoffToRegisters =
+            new Dictionary<Rhd2164AnalogHighCutoff, IReadOnlyList<int>>()
+        {
+            { Rhd2164AnalogHighCutoff.High20000Hz, new[] { 8, 0, 4, 0 } },
+            { Rhd2164AnalogHighCutoff.High15000Hz, new[] { 11, 0, 8, 0 } },
+            { Rhd2164AnalogHighCutoff.High10000Hz, new[] { 17, 0, 16, 0 } },
+            { Rhd2164AnalogHighCutoff.High7500Hz, new[] { 22, 0, 23, 0 } },
+            { Rhd2164AnalogHighCutoff.High5000Hz, new[] { 33, 0, 37, 0 } },
+            { Rhd2164AnalogHighCutoff.High3000Hz, new[] { 3, 1, 13, 1 } },
+            { Rhd2164AnalogHighCutoff.High2500Hz, new[] { 13, 1, 25, 1 } },
+            { Rhd2164AnalogHighCutoff.High2000Hz, new[] { 27, 1, 44, 1 } },
+            { Rhd2164AnalogHighCutoff.High1500Hz, new[] { 1, 2, 23, 2 } },
+            { Rhd2164AnalogHighCutoff.High1000Hz, new[] { 46, 2, 30, 3 } },
+            { Rhd2164AnalogHighCutoff.High750Hz, new[] { 41, 3, 36, 4 } },
+            { Rhd2164AnalogHighCutoff.High500Hz, new[] { 30, 5, 43, 6 } },
+            { Rhd2164AnalogHighCutoff.High300Hz, new[] { 6, 9, 2, 11 } },
+            { Rhd2164AnalogHighCutoff.High250Hz, new[] { 42, 10, 5, 13 } },
+            { Rhd2164AnalogHighCutoff.High200Hz, new[] { 24, 13, 7, 16 } },
+            { Rhd2164AnalogHighCutoff.High150Hz, new[] { 44, 17, 8, 21 } },
+            { Rhd2164AnalogHighCutoff.High100Hz, new[] { 38, 26, 5, 31 } },
+        };
+
+
+    }
+
+    public enum Rhd2164AnalogLowCutoff
+    {
+        Low500Hz,
+        Low300Hz,
+        Low250Hz,
+        Low200Hz,
+        Low150Hz,
+        Low100Hz,
+        Low75Hz,
+        Low50Hz,
+        Low30Hz,
+        Low25Hz,
+        Low20Hz,
+        Low15Hz,
+        Low10Hz,
+        Low7500mHz,
+        Low5000mHz,
+        Low3090mHz,
+        Low2500mHz,
+        Low2000mHz,
+        Low1500mHz,
+        Low1000mHz,
+        Low750mHz,
+        Low500mHz,
+        Low300mHz,
+        Low250mHz,
+        Low100mHz
+    }
+
+    public enum Rhd2164AnalogHighCutoff
+    {
+        High20000Hz,
+        High15000Hz,
+        High10000Hz,
+        High7500Hz,
+        High5000Hz,
+        High3000Hz,
+        High2500Hz,
+        High2000Hz,
+        High1500Hz,
+        High1000Hz,
+        High750Hz,
+        High500Hz,
+        High300Hz,
+        High250Hz,
+        High200Hz,
+        High150Hz,
+        High100Hz
+    }
+
     public enum Rhd2164DspCutoff
     {
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Config.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Config.cs
@@ -1,0 +1,96 @@
+﻿namespace OpenEphys.Onix
+{
+    public enum Rhd2164DspCutoff
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Differential = 0,
+
+        /// <summary>
+        /// 3310 Hz
+        /// </summary>
+        Dsp3309Hz,
+
+        /// <summary>
+        /// 1370 Hz
+        /// </summary>
+        Dsp1374Hz,
+        
+        /// <summary>
+        /// 638 Hz
+        /// </summary>
+        Dsp638Hz,
+        
+        /// <summary>
+        /// 308 Hz
+        /// </summary>
+        Dsp308Hz,
+        
+        /// <summary>
+        /// 152 Hz
+        /// </summary>
+        Dsp152Hz,
+        
+        /// <summary>
+        /// 75.2 Hz
+        /// </summary>
+        Dsp75Hz,
+        
+        /// <summary>
+        /// 37.4 Hz
+        /// </summary>
+        Dsp37Hz,
+        
+        /// <summary>
+        /// 18.7 Hz
+        /// </summary>
+        Dsp19Hz,
+        
+        /// <summary>
+        /// 9.34 Hz
+        /// </summary>
+        Dsp9336mHz,
+        
+        /// <summary>
+        /// 4.67 Hz
+        /// </summary>
+        Dsp4665mHz,
+        
+        /// <summary>
+        /// 2.33 Hz
+        /// </summary>
+        Dsp2332mHz,
+        
+        /// <summary>
+        /// 1.17 Hz
+        /// </summary>
+        Dsp1166mHz,
+        
+        /// <summary>
+        /// 0.583 Hz
+        /// </summary>
+        Dsp583mHz,
+        
+        /// <summary>
+        /// 0.291 Hz
+        /// </summary>
+        Dsp291mHz,
+        
+        /// <summary>
+        /// 0.146 Hz
+        /// </summary>
+        Dsp146mHz,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Off
+    }
+
+    public enum Rhd2164AmplifierDataFormat
+    {
+        Unsigned,
+        TwosComplement
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
@@ -28,6 +29,8 @@ namespace OpenEphys.Onix
                         var device = deviceInfo.GetDevice(typeof(Rhd2164));
                         var amplifierBuffer = new short[Rhd2164.AmplifierChannelCount * bufferSize];
                         var auxBuffer = new short[Rhd2164.AuxChannelCount * bufferSize];
+                        var hubClockBuffer = new ulong[bufferSize];
+                        var clockBuffer = new ulong[bufferSize];
 
                         var frameObserver = Observer.Create<oni.Frame>(
                             frame =>
@@ -35,11 +38,15 @@ namespace OpenEphys.Onix
                                 var payload = (Rhd2164Payload*)frame.Data.ToPointer();
                                 Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, sampleIndex * Rhd2164.AmplifierChannelCount, Rhd2164.AmplifierChannelCount);
                                 Marshal.Copy(new IntPtr(payload->AuxData), auxBuffer, sampleIndex * Rhd2164.AuxChannelCount, Rhd2164.AuxChannelCount);
+                                hubClockBuffer[sampleIndex] = unchecked((ulong)IPAddress.NetworkToHostOrder((long)payload->HubClock));
+                                clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
                                     var amplifierData = BufferHelper.CopyBuffer(amplifierBuffer, bufferSize, Rhd2164.AmplifierChannelCount, Depth.U16);
                                     var auxData = BufferHelper.CopyBuffer(auxBuffer, bufferSize, Rhd2164.AuxChannelCount, Depth.U16);
-                                    observer.OnNext(new Rhd2164DataFrame(frame.Clock, payload->HubClock, amplifierData, auxData));
+                                    observer.OnNext(new Rhd2164DataFrame(clockBuffer, hubClockBuffer, amplifierData, auxData));
+                                    hubClockBuffer = new ulong[bufferSize];
+                                    clockBuffer = new ulong[bufferSize];
                                     sampleIndex = 0;
                                 }
                             },

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class Rhd2164Data : Source<Rhd2164DataFrame>
+    {
+        [TypeConverter(typeof(Rhd2164.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<Rhd2164DataFrame> Generate()
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var device = deviceInfo.GetDevice(typeof(Rhd2164));
+                    return deviceInfo.Context.FrameReceived
+                        .Where(frame => frame.DeviceAddress == device.Address)
+                        .Select(frame => new Rhd2164DataFrame(frame));
+                }));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -26,19 +26,19 @@ namespace OpenEphys.Onix
                     {
                         var sampleIndex = 0;
                         var device = deviceInfo.GetDevice(typeof(Rhd2164));
-                        var amplifierBuffer = new short[Rhd2164Payload.AmplifierChannelCount * bufferSize];
-                        var auxBuffer = new short[Rhd2164Payload.AuxChannelCount * bufferSize];
+                        var amplifierBuffer = new short[Rhd2164.AmplifierChannelCount * bufferSize];
+                        var auxBuffer = new short[Rhd2164.AuxChannelCount * bufferSize];
 
                         var frameObserver = Observer.Create<oni.Frame>(
                             frame =>
                             {
                                 var payload = (Rhd2164Payload*)frame.Data.ToPointer();
-                                Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, sampleIndex, Rhd2164Payload.AmplifierChannelCount);
-                                Marshal.Copy(new IntPtr(payload->AuxData), amplifierBuffer, sampleIndex, Rhd2164Payload.AuxChannelCount);
+                                Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, sampleIndex * Rhd2164.AmplifierChannelCount, Rhd2164.AmplifierChannelCount);
+                                Marshal.Copy(new IntPtr(payload->AuxData), auxBuffer, sampleIndex * Rhd2164.AuxChannelCount, Rhd2164.AuxChannelCount);
                                 if (++sampleIndex >= bufferSize)
                                 {
-                                    var amplifierData = BufferHelper.CopyBuffer(amplifierBuffer, bufferSize, Rhd2164Payload.AmplifierChannelCount, Depth.U16);
-                                    var auxData = BufferHelper.CopyBuffer(auxBuffer, bufferSize, Rhd2164Payload.AuxChannelCount, Depth.U16);
+                                    var amplifierData = BufferHelper.CopyBuffer(amplifierBuffer, bufferSize, Rhd2164.AmplifierChannelCount, Depth.U16);
+                                    var auxData = BufferHelper.CopyBuffer(auxBuffer, bufferSize, Rhd2164.AuxChannelCount, Depth.U16);
                                     observer.OnNext(new Rhd2164DataFrame(frame.Clock, payload->HubClock, amplifierData, auxData));
                                     sampleIndex = 0;
                                 }

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -14,7 +14,7 @@ namespace OpenEphys.Onix
         [TypeConverter(typeof(Rhd2164.NameConverter))]
         public string DeviceName { get; set; }
 
-        public int BufferSize { get; set; }
+        public int BufferSize { get; set; } = 30;
 
         public unsafe override IObservable<Rhd2164DataFrame> Generate()
         {

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Net;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
@@ -38,7 +37,7 @@ namespace OpenEphys.Onix
                                 var payload = (Rhd2164Payload*)frame.Data.ToPointer();
                                 Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, sampleIndex * Rhd2164.AmplifierChannelCount, Rhd2164.AmplifierChannelCount);
                                 Marshal.Copy(new IntPtr(payload->AuxData), auxBuffer, sampleIndex * Rhd2164.AuxChannelCount, Rhd2164.AuxChannelCount);
-                                hubClockBuffer[sampleIndex] = unchecked((ulong)IPAddress.NetworkToHostOrder((long)payload->HubClock));
+                                hubClockBuffer[sampleIndex] = BitHelper.SwapEndian(payload->HubClock);
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Runtime.InteropServices;
 using Bonsai;
+using OpenCV.Net;
 
 namespace OpenEphys.Onix
 {
@@ -11,17 +14,41 @@ namespace OpenEphys.Onix
         [TypeConverter(typeof(Rhd2164.NameConverter))]
         public string DeviceName { get; set; }
 
-        public override IObservable<Rhd2164DataFrame> Generate()
+        public int BufferSize { get; set; }
+
+        public unsafe override IObservable<Rhd2164DataFrame> Generate()
         {
+            var bufferSize = BufferSize;
             return Observable.Using(
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
-                {
-                    var device = deviceInfo.GetDevice(typeof(Rhd2164));
-                    return deviceInfo.Context.FrameReceived
-                        .Where(frame => frame.DeviceAddress == device.Address)
-                        .Select(frame => new Rhd2164DataFrame(frame));
-                }));
+                    Observable.Create<Rhd2164DataFrame>(observer =>
+                    {
+                        var sampleIndex = 0;
+                        var device = deviceInfo.GetDevice(typeof(Rhd2164));
+                        var amplifierBuffer = new short[Rhd2164Payload.AmplifierChannelCount * bufferSize];
+                        var auxBuffer = new short[Rhd2164Payload.AuxChannelCount * bufferSize];
+
+                        var frameObserver = Observer.Create<oni.Frame>(
+                            frame =>
+                            {
+                                var payload = (Rhd2164Payload*)frame.Data.ToPointer();
+                                Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, sampleIndex, Rhd2164Payload.AmplifierChannelCount);
+                                Marshal.Copy(new IntPtr(payload->AuxData), amplifierBuffer, sampleIndex, Rhd2164Payload.AuxChannelCount);
+                                if (++sampleIndex >= bufferSize)
+                                {
+                                    var amplifierData = BufferHelper.CopyBuffer(amplifierBuffer, bufferSize, Rhd2164Payload.AmplifierChannelCount, Depth.U16);
+                                    var auxData = BufferHelper.CopyBuffer(auxBuffer, bufferSize, Rhd2164Payload.AuxChannelCount, Depth.U16);
+                                    observer.OnNext(new Rhd2164DataFrame(frame.Clock, payload->HubClock, amplifierData, auxData));
+                                    sampleIndex = 0;
+                                }
+                            },
+                            observer.OnError,
+                            observer.OnCompleted);
+                        return deviceInfo.Context.FrameReceived
+                            .Where(frame => frame.DeviceAddress == device.Address)
+                            .SubscribeSafe(frameObserver);
+                    })));
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Runtime.InteropServices;
 using OpenCV.Net;
 
@@ -7,13 +6,12 @@ namespace OpenEphys.Onix
 {
     public class Rhd2164DataFrame
     {
-        public unsafe Rhd2164DataFrame(oni.Frame frame)
+        public Rhd2164DataFrame(ulong clock, long hubClock, Mat amplifierData, Mat auxData)
         {
-            Clock = frame.Clock;
-            var payload = (Rhd2164Payload*)frame.Data.ToPointer();
-            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder(payload->HubClock));
-            AmplifierData = MatHelper.GetMatData(64, 1, Depth.S16, payload->AmplifierData);
-            AuxData = MatHelper.GetMatData(3, 1, Depth.S16, payload->AuxData);
+            Clock = clock;
+            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder(hubClock));
+            AmplifierData = amplifierData;
+            AuxData = auxData;
         }
 
         public ulong Clock { get; }
@@ -28,8 +26,11 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential)]
     unsafe struct Rhd2164Payload
     {
+        public const int AmplifierChannelCount = 64;
+        public const int AuxChannelCount = 3;
+
         public long HubClock;
-        public fixed short AmplifierData[64];
-        public fixed short AuxData[3];
+        public fixed ushort AmplifierData[AmplifierChannelCount];
+        public fixed ushort AuxData[AuxChannelCount];
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
@@ -1,22 +1,21 @@
-﻿using System.Net;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCV.Net;
 
 namespace OpenEphys.Onix
 {
     public class Rhd2164DataFrame
     {
-        public Rhd2164DataFrame(ulong clock, long hubClock, Mat amplifierData, Mat auxData)
+        public Rhd2164DataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, Mat auxData)
         {
             Clock = clock;
-            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder(hubClock));
+            HubClock = hubClock;
             AmplifierData = amplifierData;
             AuxData = auxData;
         }
 
-        public ulong Clock { get; }
+        public ulong[] Clock { get; }
 
-        public ulong HubClock { get; }
+        public ulong[] HubClock { get; }
 
         public Mat AmplifierData { get; }
 
@@ -26,7 +25,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct Rhd2164Payload
     {
-        public long HubClock;
+        public ulong HubClock;
         public fixed ushort AmplifierData[Rhd2164.AmplifierChannelCount];
         public fixed ushort AuxData[Rhd2164.AuxChannelCount];
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
@@ -23,14 +23,11 @@ namespace OpenEphys.Onix
         public Mat AuxData { get; }
     }
 
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct Rhd2164Payload
     {
-        public const int AmplifierChannelCount = 64;
-        public const int AuxChannelCount = 3;
-
         public long HubClock;
-        public fixed ushort AmplifierData[AmplifierChannelCount];
-        public fixed ushort AuxData[AuxChannelCount];
+        public fixed ushort AmplifierData[Rhd2164.AmplifierChannelCount];
+        public fixed ushort AuxData[Rhd2164.AuxChannelCount];
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Net;
+using System.Runtime.InteropServices;
+using OpenCV.Net;
+
+namespace OpenEphys.Onix
+{
+    public class Rhd2164DataFrame
+    {
+        public unsafe Rhd2164DataFrame(oni.Frame frame)
+        {
+            Clock = frame.Clock;
+            var payload = (Rhd2164Payload*)frame.Data.ToPointer();
+            HubClock = unchecked((ulong)IPAddress.NetworkToHostOrder(payload->HubClock));
+            AmplifierData = MatHelper.GetMatData(64, 1, Depth.S16, payload->AmplifierData);
+            AuxData = MatHelper.GetMatData(3, 1, Depth.S16, payload->AuxData);
+        }
+
+        public ulong Clock { get; }
+
+        public ulong HubClock { get; }
+
+        public Mat AmplifierData { get; }
+
+        public Mat AuxData { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    unsafe struct Rhd2164Payload
+    {
+        public long HubClock;
+        public fixed short AmplifierData[64];
+        public fixed short AuxData[3];
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231Data.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class TS4231Data : Source<TS4231DataFrame>
+    {
+        [TypeConverter(typeof(TS4231.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<TS4231DataFrame> Generate()
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var device = deviceInfo.GetDevice(typeof(TS4231));
+                    return deviceInfo.Context.FrameReceived
+                        .Where(frame => frame.DeviceAddress == device.Address)
+                        .Select(frame => new TS4231DataFrame(frame));
+                }));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231DataFrame.cs
@@ -1,0 +1,47 @@
+﻿using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix
+{
+    public class TS4231DataFrame
+    {
+        public unsafe TS4231DataFrame(oni.Frame frame)
+        {
+            Clock = frame.Clock;
+            var payload = (TS4231Payload*)frame.Data.ToPointer();
+            HubClock = BitHelper.SwapEndian(payload->HubClock);
+            SensorIndex = payload->SensorIndex;
+            EnvelopeWidth = payload->EnvelopeWidth;
+            EnvelopeType = payload->EnvelopeType;
+        }
+
+        public ulong Clock { get; }
+
+        public ulong HubClock { get; }
+
+        public int SensorIndex { get; }
+
+        public uint EnvelopeWidth { get; }
+
+        public TS4231Envelope EnvelopeType { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct TS4231Payload
+    {
+        public ulong HubClock;
+        public ushort SensorIndex;
+        public uint EnvelopeWidth;
+        public TS4231Envelope EnvelopeType;
+    }
+
+    public enum TS4231Envelope : short
+    {
+        Sweep,
+        J0,
+        K0,
+        J1,
+        K1,
+        J2,
+        K2
+    }
+}


### PR DESCRIPTION
This PR adds configuration and streaming operators for all 64-channel headstage acquisition devices, including RHD2164, BNO055 and TS4231. It includes payload conversion and buffering for high-density streams and automatic voltage scanning functionality for ONIX devices using the SERDES lock register.

Fixes #23 
Fixes #24 
Fixes #25 