### PR TITLE
Ensure context is disposed if configuration fails

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -95,11 +95,15 @@ namespace OpenEphys.Onix
         public uint MaxWriteFrameSize { get; private set; }
         public Dictionary<uint, oni.Device> DeviceTable { get; private set; }
 
+        // NB: This is where actions that reconfigure the link controller, or otherwise
+        // change the device table should be executed
         internal void ConfigureLink(Action<ContextTask> action)
         {
             configureLink += action;
         }
 
+        // NB: Actions queued using this method should assume that the device table
+        // is finalized and cannot be changed
         internal void ConfigureDevice(Func<ContextTask, IDisposable> selector)
         {
             configureDevice += selector;
@@ -294,6 +298,7 @@ namespace OpenEphys.Onix
             }
             set
             {
+                // PortA and PortB each have a bit in portfunc
                 ctx.SetCustomOption((int)oni.ONIXOption.PORTFUNC, value);
             }
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -121,11 +121,20 @@ namespace OpenEphys.Onix
 
             if (deviceAction != null)
             {
+                var invocationList = deviceAction.GetInvocationList();
+                var disposable = new CompositeDisposable(invocationList.Length);
                 try
                 {
-                    return new CompositeDisposable(
-                        from selector in deviceAction.GetInvocationList().Cast<Func<ContextTask, IDisposable>>()
-                        select selector(this));
+                    foreach (var selector in invocationList.Cast<Func<ContextTask, IDisposable>>())
+                    {
+                        disposable.Add(selector(this));
+                    }
+                    return disposable;
+                }
+                catch
+                {
+                    disposable.Dispose();
+                    throw;
                 }
                 finally { Reset(); }
             }

--- a/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
@@ -22,11 +22,16 @@ namespace OpenEphys.Onix
                 var driver = Driver;
                 var index = Index;
                 var context = new ContextTask(driver, index);
-                observer.OnNext(context);
-                return Disposable.Create(() =>
+                try
+                {
+                    observer.OnNext(context);
+                    return context;
+                }
+                catch
                 {
                     context.Dispose();
-                });
+                    throw;
+                }
             });
         }
     }


### PR DESCRIPTION
The context initialization and configuration sequence can fail at multiple steps. This PR ensures that global manager state does not become invalid or stale following exception paths by disposing all partial configurations and the device context itself in case of error.

Fixes #30 