### PR TITLE
Add support for configuring passthrough mode

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -13,7 +13,7 @@ namespace OpenEphys.Onix
         public ConfigureHeadstage64()
         {
             Port = PortName.PortA;
-            LinkController.Passthrough = false;
+            LinkController.HubConfiguration = HubConfiguration.Standard;
             LinkController.MinVoltage = 5.0;
             LinkController.MaxVoltage = 7.0;
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/HubConfiguration.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HubConfiguration.cs
@@ -1,0 +1,8 @@
+﻿namespace OpenEphys.Onix
+{
+    public enum HubConfiguration
+    {
+        Standard,
+        Passthrough
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
@@ -5,6 +5,11 @@ namespace OpenEphys.Onix
 {
     internal static class ObservableExtensions
     {
+        public static IObservable<ContextTask> ConfigureHost(this IObservable<ContextTask> source, Action<ContextTask> action)
+        {
+            return source.Do(context => context.ConfigureHost(action));
+        }
+
         public static IObservable<ContextTask> ConfigureLink(this IObservable<ContextTask> source, Action<ContextTask> action)
         {
             return source.Do(context => context.ConfigureLink(action));

--- a/OpenEphys.Onix/OpenEphys.Onix/OpenEphys.Onix.csproj
+++ b/OpenEphys.Onix/OpenEphys.Onix/OpenEphys.Onix.csproj
@@ -15,7 +15,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>
-    <Version>0.1.1</Version>
+    <Version>0.1.0</Version>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/OpenEphys.Onix/OpenEphys.Onix/PassthroughState.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/PassthroughState.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace OpenEphys.Onix
+{
+    [Flags]
+    public enum PassthroughState
+    {
+        PortA = 1 << 0,
+        PortB = 1 << 2
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Properties/launchSettings.json
+++ b/OpenEphys.Onix/OpenEphys.Onix/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Executable",
       "executablePath": "$(SolutionDir)..\\Bonsai\\Bonsai.exe",
       "commandLineArgs": "--lib:$(TargetDir).",
-      "nativeDebugging": false
+      "nativeDebugging": true
     }
   }
 }


### PR DESCRIPTION
This PR adds support for configuring the hub as a passthrough device. Port voltage scanning is also generalized to allow running custom link checks using the configured link controller mode, by adding passthrough mode configuration as a third step before link configuration.

Fixes #36 