### PR TITLE
Provide reusable hub device naming strategy

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
 using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class BreakoutBoard : HubDeviceFactory, INamedElement
+    public class ConfigureBreakoutBoard : HubDeviceFactory, INamedElement
     {
         string name;
 
-        public BreakoutBoard() { Name = null; }
+        public ConfigureBreakoutBoard() { Name = null; }
 
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureHeartbeat Heartbeat { get; set; } = new();
@@ -29,7 +28,7 @@ namespace OpenEphys.Onix
             set
             {
                 name = value;
-                var baseName = string.IsNullOrWhiteSpace(name) ? nameof(BreakoutBoard) : name;
+                var baseName = string.IsNullOrWhiteSpace(name) ? nameof(ConfigureBreakoutBoard) : name;
                 foreach (var device in GetDevices())
                 {
                     device.DeviceName = $"{baseName}/{device.DeviceType.Name}";

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class ConfigureBreakoutBoard : HubDeviceFactory, INamedElement
+    public class ConfigureBreakoutBoard : HubDeviceFactory
     {
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureHeartbeat Heartbeat { get; set; } = new();

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
@@ -6,10 +6,6 @@ namespace OpenEphys.Onix
 {
     public class ConfigureBreakoutBoard : HubDeviceFactory, INamedElement
     {
-        string name;
-
-        public ConfigureBreakoutBoard() { Name = null; }
-
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureHeartbeat Heartbeat { get; set; } = new();
 
@@ -20,20 +16,6 @@ namespace OpenEphys.Onix
         {
             yield return Heartbeat;
             yield return AnalogIO;
-        }
-
-        public string Name
-        {
-            get { return name; }
-            set
-            {
-                name = value;
-                var baseName = string.IsNullOrWhiteSpace(name) ? nameof(ConfigureBreakoutBoard) : name;
-                foreach (var device in GetDevices())
-                {
-                    device.DeviceName = $"{baseName}/{device.DeviceType.Name}";
-                }
-            }
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Reactive.Disposables;
 using System.Threading;
 
 namespace OpenEphys.Onix
@@ -39,6 +38,7 @@ namespace OpenEphys.Onix
 
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
+            var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
             var hubConfiguration = HubConfiguration;
             return source.ConfigureHost(context =>
@@ -82,6 +82,11 @@ namespace OpenEphys.Onix
                     context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, 0);
                     throw new InvalidOperationException("Unable to get SERDES lock on FMC link controller.");
                 }
+            })
+            .ConfigureDevice(context =>
+            {
+                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
+                return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
-using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class ConfigureHeadstage64 : HubDeviceFactory, INamedElement
+    public class ConfigureHeadstage64 : HubDeviceFactory
     {
         PortName port;
         readonly ConfigureFmcLinkController LinkController = new();

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -57,6 +57,7 @@ namespace OpenEphys.Onix
 
         private void UpdateDeviceNames(string name)
         {
+            LinkController.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.LinkController" : null;
             Rhd2164.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.Rhd2164" : null;
             Bno055.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.Bno055" : null;
             TS4231.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.TS4231" : null;

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -6,7 +6,6 @@ namespace OpenEphys.Onix
 {
     public class ConfigureHeadstage64 : HubDeviceFactory, INamedElement
     {
-        string name;
         PortName port;
         readonly ConfigureFmcLinkController LinkController = new();
 
@@ -16,16 +15,6 @@ namespace OpenEphys.Onix
             LinkController.HubConfiguration = HubConfiguration.Standard;
             LinkController.MinVoltage = 5.0;
             LinkController.MaxVoltage = 7.0;
-        }
-
-        public string Name
-        {
-            get { return name; }
-            set
-            {
-                name = value;
-                UpdateDeviceNames(name);
-            }
         }
 
         [Category(ConfigurationCategory)]
@@ -51,16 +40,7 @@ namespace OpenEphys.Onix
                 Rhd2164.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
                 TS4231.DeviceAddress = offset + 2;
-                UpdateDeviceNames(Name);
             }
-        }
-
-        private void UpdateDeviceNames(string name)
-        {
-            LinkController.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.LinkController" : null;
-            Rhd2164.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.Rhd2164" : null;
-            Bno055.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.Bno055" : null;
-            TS4231.DeviceName = !string.IsNullOrEmpty(name) ? $"{name}.TS4231" : null;
         }
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()

--- a/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public abstract class HubDeviceFactory : DeviceFactory, INamedElement
+    {
+        string _name;
+
+        public string Name
+        {
+            get { return _name; }
+            set
+            {
+                _name = value;
+                UpdateDeviceNames(_name);
+            }
+        }
+
+        internal virtual void UpdateDeviceNames(string hubName)
+        {
+            foreach (var device in GetDevices())
+            {
+                device.DeviceName = !string.IsNullOrEmpty(hubName)
+                    ? $"{hubName}.{device.DeviceType.Name}"
+                    : string.Empty;
+            }
+        }
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            if (string.IsNullOrEmpty(_name))
+            {
+                throw new InvalidOperationException("A valid hub device name must be specified.");
+            }
+
+            var output = source;
+            foreach (var device in GetDevices())
+            {
+                output = device.Process(output);
+            }
+
+            return output;
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
@@ -5,7 +5,15 @@ namespace OpenEphys.Onix
 {
     public abstract class HubDeviceFactory : DeviceFactory, INamedElement
     {
+        const string BaseTypePrefix = "Configure";
         string _name;
+
+        protected HubDeviceFactory()
+        {
+            var baseName = GetType().Name;
+            var prefixIndex = baseName.IndexOf(BaseTypePrefix);
+            Name = prefixIndex >= 0 ? baseName.Substring(prefixIndex + BaseTypePrefix.Length) : baseName;
+        }
 
         public string Name
         {


### PR DESCRIPTION
This PR improves the hub device abstract base class to reduce the number of interfaces and manual functionality required to implement a functional hub device.

This also ensures that FMC link controller name is assigned which we use now to register the breakout FMC device with the device manager.

Fixes #40 
