### PR TITLE
Simplify device configuration and registration

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
@@ -17,7 +17,7 @@ namespace OpenEphys.Onix
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
-                    var device = deviceInfo.GetDevice(typeof(AnalogIO));
+                    var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
                     return deviceInfo.Context.FrameReceived
                         .Where(frame => frame.DeviceAddress == device.Address)
                         .Select(frame => new ManagedFrame<short>(frame));

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
@@ -17,11 +17,8 @@ namespace OpenEphys.Onix
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
-                    var device = deviceInfo.GetDevice(typeof(AnalogIO));
-                    return source.Do(data =>
-                    {
-                        deviceInfo.Context.Write(device.Address, data);
-                    });
+                    var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
+                    return source.Do(device.Write);
                 }));
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
@@ -17,7 +17,7 @@ namespace OpenEphys.Onix
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
-                    var device = deviceInfo.GetDevice(typeof(Bno055));
+                    var device = deviceInfo.GetDeviceContext(typeof(Bno055));
                     return deviceInfo.Context.FrameReceived
                         .Where(frame => frame.DeviceAddress == device.Address)
                         .Select(frame => new Bno055DataFrame(frame));

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -180,32 +180,30 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDevice(deviceAddress, AnalogIO.ID);
-                context.WriteRegister(deviceAddress, AnalogIO.ENABLE, 1);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange00);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange01);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange02);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange03);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange04);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange05);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange06);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange07);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange08);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange09);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange10);
-                context.WriteRegister(deviceAddress, AnalogIO.CH00INRANGE, (uint)InputRange11);
+                var device = context.GetDeviceContext(deviceAddress, AnalogIO.ID);
+                device.WriteRegister(AnalogIO.ENABLE, 1);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange00);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange01);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange02);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange03);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange04);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange05);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange06);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange07);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange08);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange09);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange10);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange11);
 
                 var io_reg = 0u;
                 void SetIO(int channel, ChannelDirection direction)
                 {
                     io_reg = (io_reg & ~((uint)1 << channel)) | ((uint)(direction) << channel);
-                    context.WriteRegister(deviceAddress, AnalogIO.CHDIR, io_reg);
+                    device.WriteRegister(AnalogIO.CHDIR, io_reg);
                 }
 
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
                 return new CompositeDisposable(
-                    disposable,
+                    DeviceManager.RegisterDevice(deviceName, device, DeviceType),
                     direction00.Subscribe(newValue => SetIO(0, newValue)),
                     direction01.Subscribe(newValue => SetIO(1, newValue)),
                     direction02.Subscribe(newValue => SetIO(2, newValue)),

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
@@ -20,12 +20,9 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDevice(deviceAddress, Bno055.ID);
-                context.WriteRegister(deviceAddress, Bno055.ENABLE, Enable ? 1u : 0);
-
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
-                return disposable;
+                var device = context.GetDeviceContext(deviceAddress, Bno055.ID);
+                device.WriteRegister(Bno055.ENABLE, Enable ? 1u : 0);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
@@ -35,18 +35,16 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDevice(deviceAddress, Heartbeat.ID);
-                context.WriteRegister(deviceAddress, Heartbeat.ENABLE, 1);
+                var device = context.GetDeviceContext(deviceAddress, Heartbeat.ID);
+                device.WriteRegister(Heartbeat.ENABLE, 1);
                 var subscription = beatsPerSecond.Subscribe(newValue =>
                 {
-                    var clkHz = context.ReadRegister(deviceAddress, Heartbeat.CLK_HZ);
-                    context.WriteRegister(deviceAddress, Heartbeat.CLK_DIV, clkHz / newValue);
+                    var clkHz = device.ReadRegister(Heartbeat.CLK_HZ);
+                    device.WriteRegister(Heartbeat.CLK_DIV, clkHz / newValue);
                 });
 
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
                 return new CompositeDisposable(
-                    disposable,
+                    DeviceManager.RegisterDevice(deviceName, device, DeviceType),
                     subscription
                 );
             });

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -39,9 +39,9 @@ namespace OpenEphys.Onix
             {
                 // config register format following RHD2164 datasheet
                 // https://intantech.com/files/Intan_RHD2000_series_datasheet.pdf
-                var device = context.GetDevice(deviceAddress, Rhd2164.ID);
+                var device = context.GetDeviceContext(deviceAddress, Rhd2164.ID);
 
-                var format = context.ReadRegister(deviceAddress, Rhd2164.FORMAT);
+                var format = device.ReadRegister(Rhd2164.FORMAT);
                 var amplifierDataFormat = AmplifierDataFormat;
                 format &= ~(1u << 6);
                 format |= (uint)amplifierDataFormat << 6;
@@ -60,12 +60,12 @@ namespace OpenEphys.Onix
 
                 var highCutoff = Rhd2164Config.AnalogHighCutoffToRegisters[AnalogHighCutoff];
                 var lowCutoff = Rhd2164Config.AnalogLowCutoffToRegisters[AnalogLowCutoff];
-                var bw0 = context.ReadRegister(deviceAddress, Rhd2164.BW0);
-                var bw1 = context.ReadRegister(deviceAddress, Rhd2164.BW1);
-                var bw2 = context.ReadRegister(deviceAddress, Rhd2164.BW2);
-                var bw3 = context.ReadRegister(deviceAddress, Rhd2164.BW3);
-                var bw4 = context.ReadRegister(deviceAddress, Rhd2164.BW4);
-                var bw5 = context.ReadRegister(deviceAddress, Rhd2164.BW5);
+                var bw0 = device.ReadRegister(Rhd2164.BW0);
+                var bw1 = device.ReadRegister(Rhd2164.BW1);
+                var bw2 = device.ReadRegister(Rhd2164.BW2);
+                var bw3 = device.ReadRegister(Rhd2164.BW3);
+                var bw4 = device.ReadRegister(Rhd2164.BW4);
+                var bw5 = device.ReadRegister(Rhd2164.BW5);
                 bw0 = BitHelper.Replace(bw0, 0b00111111, (uint)highCutoff[0]);
                 bw1 = BitHelper.Replace(bw1, 0b00011111, (uint)highCutoff[1]);
                 bw2 = BitHelper.Replace(bw2, 0b00111111, (uint)highCutoff[2]);
@@ -73,18 +73,16 @@ namespace OpenEphys.Onix
                 bw4 = BitHelper.Replace(bw4, 0b01111111, (uint)lowCutoff[0]);
                 bw5 = BitHelper.Replace(bw5, 0b01111111, ((uint)lowCutoff[2] << 6) & 0b01000000 |
                                                           (uint)lowCutoff[1] & 0b00111111);
-                context.WriteRegister(deviceAddress, Rhd2164.BW0, bw0);
-                context.WriteRegister(deviceAddress, Rhd2164.BW1, bw1);
-                context.WriteRegister(deviceAddress, Rhd2164.BW2, bw2);
-                context.WriteRegister(deviceAddress, Rhd2164.BW3, bw3);
-                context.WriteRegister(deviceAddress, Rhd2164.BW4, bw4);
-                context.WriteRegister(deviceAddress, Rhd2164.BW5, bw5);
-                context.WriteRegister(deviceAddress, Rhd2164.FORMAT, format);
-                context.WriteRegister(deviceAddress, Rhd2164.ENABLE, enable ? 1u : 0);
+                device.WriteRegister(Rhd2164.BW0, bw0);
+                device.WriteRegister(Rhd2164.BW1, bw1);
+                device.WriteRegister(Rhd2164.BW2, bw2);
+                device.WriteRegister(Rhd2164.BW3, bw3);
+                device.WriteRegister(Rhd2164.BW4, bw4);
+                device.WriteRegister(Rhd2164.BW5, bw5);
+                device.WriteRegister(Rhd2164.FORMAT, format);
+                device.WriteRegister(Rhd2164.ENABLE, enable ? 1u : 0);
 
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
-                return disposable;
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231.cs
@@ -20,12 +20,9 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDevice(deviceAddress, TS4231.ID);
-                context.WriteRegister(deviceAddress, TS4231.ENABLE, Enable ? 1u : 0);
-
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
-                return disposable;
+                var device = context.GetDeviceContext(deviceAddress, TS4231.ID);
+                device.WriteRegister(TS4231.ENABLE, Enable ? 1u : 0);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureTest0.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureTest0.cs
@@ -42,14 +42,11 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDevice(deviceAddress, Test0.ID);
-                context.WriteRegister(deviceAddress, Test0.ENABLE, Enable ? 1u : 0);
-                FrameRateHz = context.ReadRegister(deviceAddress, Test0.FRAMERATE);
-                DummyCount = context.ReadRegister(deviceAddress, Test0.NUMTESTWORDS);
-
-                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
-                return disposable;
+                var device = context.GetDeviceContext(deviceAddress, Test0.ID);
+                device.WriteRegister(Test0.ENABLE, Enable ? 1u : 0);
+                FrameRateHz = device.ReadRegister(Test0.FRAMERATE);
+                DummyCount = device.ReadRegister(Test0.NUMTESTWORDS);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextHelper.cs
@@ -5,7 +5,7 @@ namespace OpenEphys.Onix
 {
     static class ContextHelper
     {
-        public static Device GetDevice(this ContextTask context, uint address, int id)
+        public static DeviceContext GetDeviceContext(this ContextTask context, uint address, int id)
         {
             if (!context.DeviceTable.TryGetValue(address, out Device device))
             {
@@ -17,10 +17,10 @@ namespace OpenEphys.Onix
                 throw new InvalidOperationException($"The selected device is not a {id} device.");
             }
 
-            return device;
+            return new DeviceContext(context, device);
         }
 
-        public static Device GetDevice(this DeviceInfo deviceInfo, Type expectedType)
+        public static DeviceContext GetDeviceContext(this DeviceInfo deviceInfo, Type expectedType)
         {
             deviceInfo.AssertType(expectedType);
             if (!deviceInfo.Context.DeviceTable.TryGetValue(deviceInfo.DeviceAddress, out Device device))
@@ -30,7 +30,7 @@ namespace OpenEphys.Onix
                 );
             }
 
-            return device;
+            return new DeviceContext(deviceInfo.Context, device);
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
@@ -1,7 +1,6 @@
 ﻿using Bonsai;
 using System;
 using System.ComponentModel;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 
 namespace OpenEphys.Onix

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceContext.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceContext.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace OpenEphys.Onix
+{
+    public class DeviceContext
+    {
+        readonly ContextTask _context;
+        readonly oni.Device _device;
+
+        public DeviceContext(ContextTask context, oni.Device device)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _device = device;
+        }
+
+        public ContextTask Context => _context;
+
+        public uint Address => _device.Address;
+
+        public oni.Device DeviceMetadata => _device;
+
+        public uint ReadRegister(uint registerAddress)
+        {
+            return _context.ReadRegister(_device.Address, registerAddress);
+        }
+
+        public void WriteRegister(uint registerAddress, uint value)
+        {
+            _context.WriteRegister(_device.Address, registerAddress, value);
+        }
+
+        public void Write<T>(T data) where T : unmanaged
+        {
+            _context.Write(_device.Address, data);
+        }
+
+        public void Write<T>(T[] data) where T : unmanaged
+        {
+            _context.Write(_device.Address, data);
+        }
+
+        public void Write(IntPtr data, int dataSize)
+        {
+            _context.Write(_device.Address, data, dataSize);
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceFactory.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceFactory.cs
@@ -32,18 +32,4 @@ namespace OpenEphys.Onix
             yield return this;
         }
     }
-
-    public abstract class HubDeviceFactory : DeviceFactory
-    {
-        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
-        {
-            var output = source;
-            foreach (var device in GetDevices())
-            {
-                output = device.Process(output);
-            }
-
-            return output;
-        }
-    }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceManager.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceManager.cs
@@ -10,6 +10,12 @@ namespace OpenEphys.Onix
         static readonly Dictionary<string, ResourceHandle> deviceMap = new();
         static readonly object managerLock = new();
 
+        internal static IDisposable RegisterDevice(string name, DeviceContext device, Type deviceType)
+        {
+            var deviceInfo = new DeviceInfo(device.Context, deviceType, device.Address);
+            return RegisterDevice(name, deviceInfo);
+        }
+
         internal static IDisposable RegisterDevice(string name, DeviceInfo deviceInfo)
         {
             lock (managerLock)

--- a/OpenEphys.Onix/OpenEphys.Onix/HeartbeatCounter.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HeartbeatCounter.cs
@@ -17,7 +17,7 @@ namespace OpenEphys.Onix
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
-                    var device = deviceInfo.GetDevice(typeof(Heartbeat));
+                    var device = deviceInfo.GetDeviceContext(typeof(Heartbeat));
                     return deviceInfo.Context.FrameReceived
                         .Where(frame => frame.DeviceAddress == device.Address)
                         .Select(frame => new ManagedFrame<ushort>(frame));

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -25,7 +25,7 @@ namespace OpenEphys.Onix
                     Observable.Create<Rhd2164DataFrame>(observer =>
                     {
                         var sampleIndex = 0;
-                        var device = deviceInfo.GetDevice(typeof(Rhd2164));
+                        var device = deviceInfo.GetDeviceContext(typeof(Rhd2164));
                         var amplifierBuffer = new short[Rhd2164.AmplifierChannelCount * bufferSize];
                         var auxBuffer = new short[Rhd2164.AuxChannelCount * bufferSize];
                         var hubClockBuffer = new ulong[bufferSize];

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231Data.cs
@@ -17,7 +17,7 @@ namespace OpenEphys.Onix
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
-                    var device = deviceInfo.GetDevice(typeof(TS4231));
+                    var device = deviceInfo.GetDeviceContext(typeof(TS4231));
                     return deviceInfo.Context.FrameReceived
                         .Where(frame => frame.DeviceAddress == device.Address)
                         .Select(frame => new TS4231DataFrame(frame));

--- a/OpenEphys.Onix/OpenEphys.Onix/Test0Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Test0Data.cs
@@ -30,10 +30,10 @@ namespace OpenEphys.Onix
                 Observable.Create<Test0DataFrame>(observer =>
                 {
                     // Find number of dummy words in the frame
-                    var dummyWords = (int)deviceInfo.Context.ReadRegister(deviceInfo.DeviceAddress, Test0.NUMTESTWORDS);
+                    var device = deviceInfo.GetDeviceContext(typeof(Test0));
+                    var dummyWords = (int)device.ReadRegister(Test0.NUMTESTWORDS);
 
                     var sampleIndex = 0;
-                    var device = deviceInfo.GetDevice(typeof(Test0));
                     var dummyBuffer = new short[dummyWords * bufferSize];
                     var messageBuffer = new short[bufferSize];
                     var hubClockBuffer = new ulong[bufferSize];

--- a/OpenEphys.Onix/OpenEphys.Onix/Test0DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Test0DataFrame.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using OpenCV.Net;
 
 namespace OpenEphys.Onix


### PR DESCRIPTION
This PR refactors the device configuration and registration API to avoid passing around addresses and context variables. A new class `DeviceContext` is introduced, which provides a partial application interface to the `ContextTask` register access API targeting a specific device address.

The helper methods in `ContextHelper` were also adapted to return this device context as default, which is now recommended to be used for all device configuration pipelines.

Fixes #42 