### PR TITLE
Add harp sync device configuration and data source

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureHarpSyncInput : SingleDeviceFactory
+    {
+        public ConfigureHarpSyncInput()
+            : base(typeof(HarpSyncInput))
+        {
+            DeviceAddress = 12;
+        }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies whether the Harp sync input device is enabled.")]
+        public bool Enable { get; set; } = true;
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice(context =>
+            {
+                var device = context.GetDeviceContext(deviceAddress, HarpSyncInput.ID);
+                device.WriteRegister(HarpSyncInput.ENABLE, Enable ? 1u : 0);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+            });
+        }
+    }
+
+    static class HarpSyncInput
+    {
+        public const int ID = 30;
+
+        // managed registers
+        public const uint ENABLE = 0x0; // Enable or disable the data stream
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(HarpSyncInput))
+            {
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputData.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class HarpSyncInputData : Source<HarpSyncInputDataFrame>
+    {
+        [TypeConverter(typeof(HarpSyncInput.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<HarpSyncInputDataFrame> Generate()
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var device = deviceInfo.GetDeviceContext(typeof(HarpSyncInput));
+                    return deviceInfo.Context.FrameReceived
+                        .Where(frame => frame.DeviceAddress == device.Address)
+                        .Select(frame => new HarpSyncInputDataFrame(frame));
+                }));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputDataFrame.cs
@@ -1,0 +1,28 @@
+﻿using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix
+{
+    public class HarpSyncInputDataFrame
+    {
+        public unsafe HarpSyncInputDataFrame(oni.Frame frame)
+        {
+            Clock = frame.Clock;
+            var payload = (HarpSyncInputPayload*)frame.Data.ToPointer();
+            HubClock = BitHelper.SwapEndian(payload->HubClock);
+            HarpTime = payload->HarpTime;
+        }
+
+        public ulong Clock { get; }
+
+        public ulong HubClock { get; }
+
+        public uint HarpTime { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct HarpSyncInputPayload
+    {
+        public ulong HubClock;
+        public uint HarpTime;
+    }
+}


### PR DESCRIPTION
This PR adds configuration and streaming operators for the Harp sync input device on the ONIX board. Default address and device ID were reverse engineered using `oni-repl`. The payload structure was reverse engineered from the previous ONIX plugin.

Fixes #50 