### PR TITLE
Initial support for 64-channel headstage RHS2116 device

### DIFF
--- a/Bonsai/Bonsai.config
+++ b/Bonsai/Bonsai.config
@@ -8,18 +8,23 @@
     <Package id="Bonsai.Dsp" version="2.8.0" />
     <Package id="Bonsai.Dsp.Design" version="2.8.0" />
     <Package id="Bonsai.Editor" version="2.8.0" />
+    <Package id="Bonsai.Ephys" version="2.5.0" />
+    <Package id="Bonsai.Ephys.Design" version="2.5.0" />
     <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
     <Package id="Bonsai.System" version="2.8.0" />
     <Package id="Bonsai.System.Design" version="2.8.0" />
     <Package id="Bonsai.Vision" version="2.8.0" />
     <Package id="Bonsai.Vision.Design" version="2.8.0" />
+    <Package id="Bonsai.Windows.Input" version="2.7.0" />
+    <Package id="FTD2XX_NET" version="1.0.14" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
     <Package id="Markdig" version="0.18.1" />
     <Package id="Microsoft.Web.WebView2" version="1.0.1823.32" />
     <Package id="OpenCV.Net" version="3.4.2" />
     <Package id="OpenTK" version="3.1.0" />
     <Package id="OpenTK.GLControl" version="3.1.0" />
+    <Package id="Rhythm.Net" version="1.5.0" />
     <Package id="Rx-Core" version="2.2.5" />
     <Package id="Rx-Interfaces" version="2.2.5" />
     <Package id="Rx-Linq" version="2.2.5" />
@@ -37,12 +42,15 @@
     <AssemblyReference assemblyName="Bonsai.Dsp" />
     <AssemblyReference assemblyName="Bonsai.Dsp.Design" />
     <AssemblyReference assemblyName="Bonsai.Editor" />
+    <AssemblyReference assemblyName="Bonsai.Ephys" />
+    <AssemblyReference assemblyName="Bonsai.Ephys.Design" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions" />
     <AssemblyReference assemblyName="Bonsai.Scripting.Expressions.Design" />
     <AssemblyReference assemblyName="Bonsai.System" />
     <AssemblyReference assemblyName="Bonsai.System.Design" />
     <AssemblyReference assemblyName="Bonsai.Vision" />
     <AssemblyReference assemblyName="Bonsai.Vision.Design" />
+    <AssemblyReference assemblyName="Bonsai.Windows.Input" />
   </AssemblyReferences>
   <AssemblyLocations>
     <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.1\lib\net48\Bonsai.exe" />
@@ -52,12 +60,17 @@
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.Design.2.8.0\lib\net462\Bonsai.Dsp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Ephys" processorArchitecture="MSIL" location="Packages\Bonsai.Ephys.2.5.0\lib\net472\Bonsai.Ephys.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Ephys.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Ephys.Design.2.5.0\lib\net472\Bonsai.Ephys.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.2.8.0\lib\net462\Bonsai.Scripting.Expressions.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.0\lib\net462\Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages\Bonsai.System.Design.2.8.0\lib\net462\Bonsai.System.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.0\lib\net462\Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Windows.Input" processorArchitecture="MSIL" location="Packages\Bonsai.Windows.Input.2.7.0\lib\net462\Bonsai.Windows.Input.dll" />
+    <AssemblyLocation assemblyName="FTD2XX_NET" processorArchitecture="MSIL" location="Packages\FTD2XX_NET.1.0.14\lib\net40\FTD2XX_NET.dll" />
+    <AssemblyLocation assemblyName="libFrontPanel-csharp" processorArchitecture="MSIL" location="Packages\Rhythm.Net.1.5.0\lib\net40\libFrontPanel-csharp.dll" />
     <AssemblyLocation assemblyName="Markdig" processorArchitecture="MSIL" location="Packages\Markdig.0.18.1\lib\net40\Markdig.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.Core" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.Core.dll" />
     <AssemblyLocation assemblyName="Microsoft.Web.WebView2.WinForms" processorArchitecture="MSIL" location="Packages\Microsoft.Web.WebView2.1.0.1823.32\lib\net45\Microsoft.Web.WebView2.WinForms.dll" />
@@ -65,6 +78,7 @@
     <AssemblyLocation assemblyName="OpenCV.Net" processorArchitecture="MSIL" location="Packages\OpenCV.Net.3.4.2\lib\net462\OpenCV.Net.dll" />
     <AssemblyLocation assemblyName="OpenTK" processorArchitecture="MSIL" location="Packages\OpenTK.3.1.0\lib\net20\OpenTK.dll" />
     <AssemblyLocation assemblyName="OpenTK.GLControl" processorArchitecture="MSIL" location="Packages\OpenTK.GLControl.3.1.0\lib\net20\OpenTK.GLControl.dll" />
+    <AssemblyLocation assemblyName="Rhythm.Net" processorArchitecture="MSIL" location="Packages\Rhythm.Net.1.5.0\lib\net40\Rhythm.Net.dll" />
     <AssemblyLocation assemblyName="ScintillaNET" processorArchitecture="MSIL" location="Packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll" />
     <AssemblyLocation assemblyName="SVG" processorArchitecture="MSIL" location="Packages\SvgNet.3.3.3\lib\net462\SVG.dll" />
     <AssemblyLocation assemblyName="System.Linq.Dynamic" processorArchitecture="MSIL" location="Packages\System.Linq.Dynamic.1.0.7\lib\net40\System.Linq.Dynamic.dll" />
@@ -84,5 +98,7 @@
     <LibraryFolder path="Packages\Microsoft.Web.WebView2.1.0.1823.32\runtimes\win-x86\native_uap" platform="x86" />
     <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x64\native\vc14\bin" platform="x64" />
     <LibraryFolder path="Packages\OpenCV.Net.3.4.2\runtimes\win-x86\native\vc14\bin" platform="x86" />
+    <LibraryFolder path="Packages\Rhythm.Net.1.5.0\build\native\bin\x64" platform="x64" />
+    <LibraryFolder path="Packages\Rhythm.Net.1.5.0\build\native\bin\x86" platform="x86" />
   </LibraryFolders>
 </PackageConfiguration>

--- a/Bonsai/NuGet.config
+++ b/Bonsai/NuGet.config
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="Gallery" value="..\..\Gallery" />
     <add key="Bonsai Packages" value="https://www.myget.org/F/bonsai/api/v3/index.json" />
     <add key="Community Packages" value="https://www.myget.org/F/bonsai-community/api/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <add key="Gallery" value="true" />
+  </disabledPackageSources>
 </configuration>

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -89,6 +89,11 @@ namespace OpenEphys.Onix
                         context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, voltage + safetyVoltage);
                         Thread.Sleep(VoltageOnSettleMillis);
                         hasLock = CheckLinkState(device); // Final check
+
+                        // TODO: HACK HACK HACK. HeadstageRhs2116 needs a reset after power on to present device table.  HACK HACK HACK.
+                        Thread.Sleep(500);
+                        context.Reset(); 
+
                         break;
                     }
                 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -33,11 +33,11 @@ namespace OpenEphys.Onix
 
         [Description("Link voltage turn off settle time in milliseconds.")]
         [Range(0, 1000)]
-        public int VoltageOffSettleMillis { get; set; } = 500;
+        public int VoltageOffSettleMillis { get; set; } = 200;
 
         [Description("Link voltage turn on settle time in milliseconds.")]
         [Range(0, 1000)]
-        public int VoltageOnSettleMillis { get; set; } = 1000;
+        public int VoltageOnSettleMillis { get; set; } = 200;
 
         [Description("Specifies an optional link voltage offset to ensure stable operation after lock is established.")]
         public double VoltageOffset { get; set; } = 0.2;
@@ -79,6 +79,7 @@ namespace OpenEphys.Onix
                     Thread.Sleep(VoltageOffSettleMillis);
                     context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, voltage);
                     Thread.Sleep(VoltageOnSettleMillis);
+                    context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, 33); // Actively pull voltage to lowest level before turning off
 
                     if (CheckLinkState(device))
                     {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -79,9 +79,10 @@ namespace OpenEphys.Onix
                     Thread.Sleep(VoltageOffSettleMillis);
                     context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, voltage);
                     Thread.Sleep(VoltageOnSettleMillis);
+                    hasLock = CheckLinkState(device);
                     context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, 33); // Actively pull voltage to lowest level before turning off
 
-                    if (CheckLinkState(device))
+                    if (hasLock)
                     {
                         context.WriteRegister(deviceAddress, FmcLinkController.PORTVOLTAGE, 0);
                         Thread.Sleep(VoltageOffSettleMillis);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -35,6 +35,10 @@ namespace OpenEphys.Onix
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureTS4231 TS4231 { get; set; } = new() { Enable = false };
 
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureHeadstage64ElectricalStimulator ElectricalStimulator { get; set; } = new() { Enable = false };
+
         public PortName Port
         {
             get { return port; }
@@ -46,6 +50,7 @@ namespace OpenEphys.Onix
                 Rhd2164.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
                 TS4231.DeviceAddress = offset + 2;
+                ElectricalStimulator.DeviceAddress = offset + 3;
             }
         }
 
@@ -55,6 +60,7 @@ namespace OpenEphys.Onix
             yield return Rhd2164;
             yield return Bno055;
             yield return TS4231;
+            yield return ElectricalStimulator;
         }
     }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -17,10 +17,12 @@ namespace OpenEphys.Onix
             Port = PortName.PortA;
             LinkController.HubConfiguration = HubConfiguration.Standard;
             LinkController.MinVoltage = 3.3;
-            LinkController.MaxVoltage = 5.0;
-            LinkController.VoltageOffset = 3.0;
-
+            LinkController.MaxVoltage = 6.0;
+            LinkController.VoltageOffset = 3.4;
+            LinkController.VoltageOffSettleMillis = 4000; // TODO: It takes a huge amount of time to get to 0, almost 10 seconds
+            LinkController.VoltageOnSettleMillis = 100;
         }
+
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureRhd2164 Rhd2164 { get; set; } = new();

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -10,12 +10,17 @@ namespace OpenEphys.Onix
 
         public ConfigureHeadstage64()
         {
+            // TODO: The issue with this headstage is that its locking voltage is far, far lower than the votlage requried for full
+            // functionality. Locking occurs at aroud 2V on the headstage (enough to turn 1.8V on). Full functionality is 5.0 volts.
+            // Whats worse: the port voltage can only go down to 3.3V, which means that its very hard to find a the true lowest voltage
+            // for a lock and then add a large offset to that.
             Port = PortName.PortA;
             LinkController.HubConfiguration = HubConfiguration.Standard;
-            LinkController.MinVoltage = 5.0;
-            LinkController.MaxVoltage = 7.0;
-        }
+            LinkController.MinVoltage = 3.3;
+            LinkController.MaxVoltage = 5.0;
+            LinkController.VoltageOffset = 3.0;
 
+        }
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureRhd2164 Rhd2164 { get; set; } = new();

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64ElectricalStimulator.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64ElectricalStimulator.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing.Design;
+using System.Reactive.Disposables;
+using System.Reactive.Subjects;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureHeadstage64ElectricalStimulator : SingleDeviceFactory
+    {
+
+        readonly BehaviorSubject<double> phaseOneCurrent = new(0);
+        readonly BehaviorSubject<double> interPhaseCurrent = new(0);
+        readonly BehaviorSubject<double> phaseTwoCurrent = new(0);
+        readonly BehaviorSubject<uint> phaseOneDuration = new(0);
+        readonly BehaviorSubject<uint> interPhaseInterval = new(0);
+        readonly BehaviorSubject<uint> phaseTwoDuration = new(0);
+        readonly BehaviorSubject<uint> interPulseInterval = new(0);
+        readonly BehaviorSubject<uint> burstPulseCount = new(0);
+        readonly BehaviorSubject<uint> interBurstInterval = new(0);
+        readonly BehaviorSubject<uint> trainBurstCount = new(0);
+        readonly BehaviorSubject<uint> trainDelay = new(0);
+        readonly BehaviorSubject<bool> powerEnable = new(false);
+
+        const double DacBitDepth = 16;
+        const double AbsMaxMicroAmps = 2500;
+
+        public ConfigureHeadstage64ElectricalStimulator()
+            : base(typeof(Headstage64ElectricalStimulator))
+        {
+        }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies whether the electrical stimulation subcircuit will respect triggers.")]
+        public bool Enable { get; set; } = true;
+
+        [Category(AcquisitionCategory)]
+        [Description("Phase 1 pulse current (uA).")]
+        [Range(-AbsMaxMicroAmps, AbsMaxMicroAmps)]
+        [Editor(DesignTypes.SliderEditor, typeof(UITypeEditor))]
+        [Precision(3, 1)]
+        public double PhaseOneCurrent
+        {
+            get => phaseOneCurrent.Value;
+            set => phaseOneCurrent.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Interphase rest current (uA).")]
+        [Range(-AbsMaxMicroAmps, AbsMaxMicroAmps)]
+        [Editor(DesignTypes.SliderEditor, typeof(UITypeEditor))]
+        [Precision(3, 1)]
+        public double InterPhaseCurrent
+        {
+            get => interPhaseCurrent.Value;
+            set => interPhaseCurrent.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Phase 2 pulse current (uA).")]
+        [Range(-AbsMaxMicroAmps, AbsMaxMicroAmps)]
+        [Editor(DesignTypes.SliderEditor, typeof(UITypeEditor))]
+        [Precision(3, 1)]
+        public double PhaseTwoCurrent
+        {
+            get => phaseTwoCurrent.Value;
+            set => phaseTwoCurrent.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Pulse train start delay (uSec).")]
+        [Range(0, uint.MaxValue)]
+        public uint TrainDelay
+        {
+            get => trainDelay.Value;
+            set => trainDelay.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Phase 1 pulse duration (uSec).")]
+        [Range(0, uint.MaxValue)]
+        public uint PhaseOneDuration
+        {
+            get => phaseOneDuration.Value;
+            set => phaseOneDuration.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Inter-phase interval (uSec).")]
+        [Range(0, uint.MaxValue)]
+        public uint InterPhaseInterval
+        {
+            get => interPhaseInterval.Value;
+            set => interPhaseInterval.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Phase 2 pulse duration (uSec).")]
+        [Range(0, uint.MaxValue)]
+        public uint PhaseTwoDuration
+        {
+            get => phaseTwoDuration.Value;
+            set => phaseTwoDuration.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Inter-pulse interval (uSec).")]
+        [Range(0, uint.MaxValue)]
+        public uint InterPulseInterval
+        {
+            get => interPulseInterval.Value;
+            set => interPulseInterval.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Inter-burst interval (uSec).")]
+        [Range(0, uint.MaxValue)]
+        public uint InterBurstInterval
+        {
+            get => interBurstInterval.Value;
+            set => interBurstInterval.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Number of pulses in each burst.")]
+        [Range(0, uint.MaxValue)]
+        public uint BurstPulseCount
+        {
+            get => burstPulseCount.Value;
+            set => burstPulseCount.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Number of bursts in each train.")]
+        [Range(0, uint.MaxValue)]
+        public uint TrainBurstCount
+        {
+            get => trainBurstCount.Value;
+            set => trainBurstCount.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Stimulator power on/off.")]
+        [Range(0, uint.MaxValue)]
+        public bool PowerEnable
+        {
+            get => powerEnable.Value;
+            set => powerEnable.OnNext(value);
+        }
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice(context =>
+            {
+                var device = context.GetDeviceContext(deviceAddress, Headstage64ElectricalStimulator.ID);
+                device.WriteRegister(Headstage64ElectricalStimulator.ENABLE, Enable ? 1u : 0u);
+
+                static uint uAToCode(double currentuA)
+                {
+                    var k = 1 / (2 * AbsMaxMicroAmps / (Math.Pow(2, DacBitDepth) - 1)); // static
+                    return (uint)(k * (currentuA + AbsMaxMicroAmps));
+                }
+
+                return new CompositeDisposable(
+                    DeviceManager.RegisterDevice(deviceName, device, DeviceType),
+                    phaseOneCurrent.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT1, uAToCode(newValue))),
+                    interPhaseCurrent.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.RESTCURR, uAToCode(newValue))),
+                    phaseTwoCurrent.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT2, uAToCode(newValue))),
+                    trainDelay.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.TRAINDELAY, newValue)),
+                    phaseOneDuration.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.PULSEDUR1, newValue)),
+                    interPhaseInterval.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.INTERPHASEINTERVAL, newValue)),
+                    phaseTwoDuration.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.PULSEDUR2, newValue)),
+                    interPulseInterval.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.INTERPULSEINTERVAL, newValue)),
+                    interBurstInterval.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.INTERBURSTINTERVAL, newValue)),
+                    burstPulseCount.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.BURSTCOUNT, newValue)),
+                    trainBurstCount.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.TRAINCOUNT, newValue)),
+                    powerEnable.Subscribe(newValue => device.WriteRegister(Headstage64ElectricalStimulator.POWERON, newValue ? 1u: 0u))
+                );
+
+            });
+        }
+    }
+
+    static class Headstage64ElectricalStimulator
+    {
+        public const int ID = 4;
+
+        // managed registers
+        public const uint NULLPARM = 0; // No command
+        public const uint BIPHASIC = 1; // Biphasic pulse (0 = monophasic, 1 = biphasic; NB: currently ignored)
+        public const uint CURRENT1 = 2; // Phase 1 current
+        public const uint CURRENT2 = 3; // Phase 2 current
+        public const uint PULSEDUR1 = 4; // Phase 1 duration, 1 microsecond steps
+        public const uint INTERPHASEINTERVAL = 5; // Inter-phase interval, 10 microsecond steps
+        public const uint PULSEDUR2 = 6; // Phase 2 duration, 1 microsecond steps
+        public const uint INTERPULSEINTERVAL = 7; // Inter-pulse interval, 10 microsecond steps
+        public const uint BURSTCOUNT = 8; // Burst duration, number of pulses in burst
+        public const uint INTERBURSTINTERVAL = 9; // Inter-burst interval, microseconds
+        public const uint TRAINCOUNT = 10; // Pulse train duration, number of bursts in train
+        public const uint TRAINDELAY = 11; // Pulse train delay, microseconds
+        public const uint TRIGGER = 12; // Trigger stimulation (1 = deliver)
+        public const uint POWERON = 13; // Control estim sub-circuit power (0 = off, 1 = on)
+        public const uint ENABLE = 14; // If 0 then stimulation triggers will be ignored, otherwise they will be applied 
+        public const uint RESTCURR = 15; // Resting current between pulse phases
+        public const uint RESET = 16; // Reset all parameters to default
+        public const uint REZ = 17; // Internal DAC resolution in bits
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(Headstage64ElectricalStimulator))
+            {
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstageRhs2116.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstageRhs2116.cs
@@ -31,11 +31,16 @@ namespace OpenEphys.Onix
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureRhs2116 Rhs2116B { get; set; } = new();
 
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureRhs2116Trigger StimulusTrigger { get; set; } = new();
+
         internal override void UpdateDeviceNames(string hubName)
         {
             LinkController.DeviceName = $"{hubName}/{nameof(LinkController)}";
             Rhs2116A.DeviceName = $"{hubName}/{nameof(Rhs2116A)}";
             Rhs2116B.DeviceName = $"{hubName}/{nameof(Rhs2116B)}";
+            StimulusTrigger.DeviceName = $"{hubName}/{nameof(StimulusTrigger)}";
         }
 
         public PortName Port
@@ -48,6 +53,7 @@ namespace OpenEphys.Onix
                 LinkController.DeviceAddress = (uint)port;
                 Rhs2116A.DeviceAddress = offset + 0;
                 Rhs2116B.DeviceAddress = offset + 1;
+                StimulusTrigger.DeviceAddress = offset + 2;
             }
         }
 
@@ -56,6 +62,7 @@ namespace OpenEphys.Onix
             yield return LinkController;
             yield return Rhs2116A;
             yield return Rhs2116B;
+            yield return StimulusTrigger;
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstageRhs2116.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstageRhs2116.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureHeadstageRhs2116 : HubDeviceFactory
+    {
+        PortName port;
+        readonly ConfigureFmcLinkController LinkController = new();
+
+        public ConfigureHeadstageRhs2116()
+        {
+            // TODO: The issue with this headstage is that its locking voltage is far, far lower than the votlage requried for full
+            // functionality. Locking occurs at aroud 2V on the headstage (enough to turn 1.8V on). Full functionality is 5.0 volts.
+            // Whats worse: the port voltage can only go down to 3.3V, which means that its very hard to find a the true lowest voltage
+            // for a lock and then add a large offset to that.
+            Port = PortName.PortA;
+            LinkController.HubConfiguration = HubConfiguration.Standard;
+            LinkController.MinVoltage = 3.3;
+            LinkController.MaxVoltage = 5.0;
+            LinkController.VoltageOffset = 2.5;
+            LinkController.VoltageOffSettleMillis = 500;
+            LinkController.VoltageOnSettleMillis = 100;
+        }
+
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureRhs2116 Rhs2116A { get; set; } = new();
+
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureRhs2116 Rhs2116B { get; set; } = new();
+
+        internal override void UpdateDeviceNames(string hubName)
+        {
+            LinkController.DeviceName = $"{hubName}/{nameof(LinkController)}";
+            Rhs2116A.DeviceName = $"{hubName}/{nameof(Rhs2116A)}";
+            Rhs2116B.DeviceName = $"{hubName}/{nameof(Rhs2116B)}";
+        }
+
+        public PortName Port
+        {
+            get { return port; }
+            set
+            {
+                port = value;
+                var offset = (uint)port << 8;
+                LinkController.DeviceAddress = (uint)port;
+                Rhs2116A.DeviceAddress = offset + 0;
+                Rhs2116B.DeviceAddress = offset + 1;
+            }
+        }
+
+        internal override IEnumerable<IDeviceConfiguration> GetDevices()
+        {
+            yield return LinkController;
+            yield return Rhs2116A;
+            yield return Rhs2116B;
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhs2116.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhs2116.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureRhs2116 : SingleDeviceFactory
+    {
+
+        readonly BehaviorSubject<Rhs2116AnalogLowCutoff> analogLowCutoff = new(Rhs2116AnalogLowCutoff.Low100mHz);
+        readonly BehaviorSubject<Rhs2116AnalogLowCutoff> analogLowCutoffRecovery = new(Rhs2116AnalogLowCutoff.Low250Hz);
+        readonly BehaviorSubject<Rhs2116AnalogHighCutoff> analogHighCutoff = new(Rhs2116AnalogHighCutoff.High10000Hz);
+        readonly BehaviorSubject<bool> respectExternalActiveStim = new(true);
+        // TODO: readonly BehaviorSubject<Rhs2116StimuluSequence> stimulusSequence = new(BehaviorSubject<Rhs2116StimuluSequence>);
+
+        public ConfigureRhs2116()
+            : base(typeof(Rhs2116))
+        {
+        }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies whether the RHS2116 device is enabled.")]
+        public bool Enable { get; set; } = true;
+
+        //[Category(ConfigurationCategory)]
+        //[Description("Specifies the raw ADC output format used for amplifier conversions.")]
+        //public Rhs2116AmplifierDataFormat AmplifierDataFormat { get; set; }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies the cutoff frequency for the DSP high-pass filter used for amplifier offset removal.")]
+        public Rhs2116DspCutoff DspCutoff { get; set; } = Rhs2116DspCutoff.Off;
+
+        [Category(AcquisitionCategory)]
+        [Description("Specifies the lower cutoff frequency of the pre-ADC amplifiers.")]
+        public Rhs2116AnalogLowCutoff AnalogLowCutoff
+        {
+            get => analogLowCutoff.Value;
+            set => analogLowCutoff.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Specifies the lower cutoff frequency of the pre-ADC amplifiers during stimulus recovery.")]
+        public Rhs2116AnalogLowCutoff AnalogLowCutoffRecovery
+        {
+            get => analogLowCutoffRecovery.Value;
+            set => analogLowCutoffRecovery.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("Specifies the upper cutoff frequency of the pre-ADC amplifiers.")]
+        public Rhs2116AnalogHighCutoff AnalogHighCutoff
+        {
+            get => analogHighCutoff.Value;
+            set => analogHighCutoff.OnNext(value);
+        }
+
+        [Category(AcquisitionCategory)]
+        [Description("If true, this device will apply AnalogLowCutoffRecovery " +
+            "if stimulation occurs via any RHS chip the same headstage or others that are connected" +
+            "using StimActive pin. If false, this device will apply AnalogLowCutoffRecovery during its" +
+            "own stimuli.")]
+        public bool RespectExternalActiveStim
+        {
+            get => respectExternalActiveStim.Value;
+            set => respectExternalActiveStim.OnNext(value);
+        }
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            var enable = Enable;
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice(context =>
+            {
+                // config register format following RHS2116 datasheet
+                // https://www.intantech.com/files/Intan_RHS2116_datasheet.pdf
+                var device = context.GetDeviceContext(deviceAddress, Rhs2116.ID);
+
+                var format = device.ReadRegister(Rhs2116.FORMAT);
+                var dspCutoff = DspCutoff;
+                if (dspCutoff == Rhs2116DspCutoff.Off)
+                {
+                    format &= ~(1u << 4);
+                }
+                else
+                {
+                    format |= 1 << 4;
+                    format &= ~0xFu;
+                    format |= (uint)dspCutoff;
+                }
+
+                device.WriteRegister(Rhs2116.FORMAT, format);
+                device.WriteRegister(Rhs2116.ENABLE, enable ? 1u : 0);
+
+                return new CompositeDisposable(
+                   DeviceManager.RegisterDevice(deviceName, device, DeviceType),
+                   analogLowCutoff.Subscribe(newValue => {
+                       var regs = Rhs2116Config.AnalogLowCutoffToRegisters[newValue];
+                       var reg = regs[2] << 13 | regs[1] << 7 | regs[0];
+                       device.WriteRegister(Rhs2116.BW2, reg);
+                   }),
+                   analogLowCutoffRecovery.Subscribe(newValue => {
+                       var regs = Rhs2116Config.AnalogLowCutoffToRegisters[newValue];
+                       var reg = regs[2] << 13 | regs[1] << 7 | regs[0];
+                       device.WriteRegister(Rhs2116.BW3, reg);
+                   }),
+                   analogHighCutoff.Subscribe(newValue => {
+                       var regs = Rhs2116Config.AnalogHighCutoffToRegisters[newValue];
+                       device.WriteRegister(Rhs2116.BW0, regs[1] << 6 | regs[0]);
+                       device.WriteRegister(Rhs2116.BW1, regs[3] << 6 | regs[2]);
+                       device.WriteRegister(Rhs2116.FASTSETTLESAMPLES, Rhs2116Config.AnalogHighCutoffToFastSettleSamples[newValue]);
+                    })
+               );
+            });
+        }
+    }
+
+    static class Rhs2116
+    {
+        public const int ID = 31;
+
+        // constants
+        public const int AmplifierChannelCount = 16;
+
+        // managed registers
+        public const uint ENABLE = 0x8000; // Enable or disable the data output stream (32767)
+        public const uint MAXDELTAS = 0x8001; // Maximum number of deltas in the delta table (32769)
+        public const uint NUMDELTAS = 0x8002; // Number of deltas in the delta table (32770)
+        public const uint DELTAIDXTIME = 0x8003; // The delta table index and corresponding application delta application time (32771)
+        public const uint DELTAPOLEN = 0x8004; // The polarity and enable vectors  (32772)
+        public const uint SEQERROR = 0x8005; // Invalid sequence indicator (32773)
+        public const uint TRIGGER = 0x8006;  // Writing 1 to this register will trigger a stimulation sequence for this device (32774)
+        public const uint FASTSETTLESAMPLES = 0x8007; // Number of round-robbin samples to apply charge balance following the conclusion of a stimulus pulse (32775)
+        public const uint RESPECTSTIMACTIVE = 0x8008; // Determines when artifact recovery sequence is applied to this chip (32776)
+
+        // unmanaged registers
+        public const uint BIAS = 0x00; // Supply Sensor and ADC Buffer Bias Current
+        public const uint FORMAT = 0x01; // ADC Output Format, DSP Offset Removal, and Auxiliary Digital Outputs
+        public const uint ZCHECK = 0x02; // Impedance Check Control
+        public const uint DAC = 0x03; // Impedance Check DAC
+        public const uint BW0 = 0x04; // On-Chip Amplifier Bandwidth Select
+        public const uint BW1 = 0x05; // On-Chip Amplifier Bandwidth Select
+        public const uint BW2 = 0x06; // On-Chip Amplifier Bandwidth Select
+        public const uint BW3 = 0x07; // On-Chip Amplifier Bandwidth Select
+        public const uint PWR = 0x08; //Individual AC Amplifier Power
+
+        public const uint SETTLE = 0x0a; // Amplifier Fast Settle
+
+        public const uint LOWAB = 0x0c; // Amplifier Lower Cutoff Frequency Select
+
+        public const uint STIMENA = 0x20; // Stimulation Enable A
+        public const uint STIMENB = 0x21; // Stimulation Enable B
+        public const uint STEPSZ = 0x22; // Stimulation Current Step Size
+        public const uint STIMBIAS = 0x23; // Stimulation Bias Voltages
+        public const uint RECVOLT = 0x24; // Current-Limited Charge Recovery Target Voltage
+        public const uint RECCUR = 0x25; // Charge Recovery Current Limit
+        public const uint DCPWR = 0x26; // Individual DC Amplifier Power
+
+        public const uint COMPMON = 0x28; // Compliance Monitor
+
+        public const uint STIMON = 0x2a; // Stimulator On
+
+        public const uint STIMPOL = 0x2c; // Stimulator Polarity
+
+        public const uint RECOV = 0x2e; // Charge Recovery Switch
+
+        public const uint LIMREC = 0x30; // Current-Limited Charge Recovery Enable
+
+        public const uint FAULTDET = 0x32; // Fault Current Detector
+
+        public const uint NEG00 = 0x40;
+        public const uint NEG01 = 0x41;
+        public const uint NEG02 = 0x42;
+        public const uint NEG03 = 0x43;
+        public const uint NEG04 = 0x44;
+        public const uint NEG05 = 0x45;
+        public const uint NEG06 = 0x46;
+        public const uint NEG07 = 0x47;
+        public const uint NEG08 = 0x48;
+        public const uint NEG09 = 0x49;
+        public const uint NEG010 = 0x4a;
+        public const uint NEG011 = 0x4b;
+        public const uint NEG012 = 0x4c;
+        public const uint NEG013 = 0x4d;
+        public const uint NEG014 = 0x4e;
+        public const uint NEG015 = 0x4f;
+
+        public const uint POS00 = 0x60;
+        public const uint POS01 = 0x61;
+        public const uint POS02 = 0x62;
+        public const uint POS03 = 0x63;
+        public const uint POS04 = 0x64;
+        public const uint POS05 = 0x65;
+        public const uint POS06 = 0x66;
+        public const uint POS07 = 0x67;
+        public const uint POS08 = 0x68;
+        public const uint POS09 = 0x69;
+        public const uint POS010 = 0x6a;
+        public const uint POS011 = 0x6b;
+        public const uint POS012 = 0x6c;
+        public const uint POS013 = 0x6d;
+        public const uint POS014 = 0x6e;
+        public const uint POS015 = 0x6f;
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(Rhs2116))
+            {
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhs2116.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhs2116.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -13,7 +14,7 @@ namespace OpenEphys.Onix
         readonly BehaviorSubject<Rhs2116AnalogLowCutoff> analogLowCutoffRecovery = new(Rhs2116AnalogLowCutoff.Low250Hz);
         readonly BehaviorSubject<Rhs2116AnalogHighCutoff> analogHighCutoff = new(Rhs2116AnalogHighCutoff.High10000Hz);
         readonly BehaviorSubject<bool> respectExternalActiveStim = new(true);
-        // TODO: readonly BehaviorSubject<Rhs2116StimuluSequence> stimulusSequence = new(BehaviorSubject<Rhs2116StimuluSequence>);
+        readonly BehaviorSubject<Rhs2116StimulusSequence> stimulusSequence = new(new Rhs2116StimulusSequence());
 
         public ConfigureRhs2116()
             : base(typeof(Rhs2116))
@@ -67,6 +68,14 @@ namespace OpenEphys.Onix
             set => respectExternalActiveStim.OnNext(value);
         }
 
+        [Category(AcquisitionCategory)]
+        [Description("Stimulus sequence.")]
+        public Rhs2116StimulusSequence StimulusSequence
+        {
+            get => stimulusSequence.Value;
+            set => stimulusSequence.OnNext(value);
+        }
+
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
             var enable = Enable;
@@ -91,28 +100,65 @@ namespace OpenEphys.Onix
                     format |= (uint)dspCutoff;
                 }
 
-                device.WriteRegister(Rhs2116.FORMAT, format);
+                device.WriteRegister(Rhs2116.FORMAT, format); // NB: DC data only provided in unsigned. Force amplifier data to use unsigned for consistency
                 device.WriteRegister(Rhs2116.ENABLE, enable ? 1u : 0);
 
                 return new CompositeDisposable(
-                   DeviceManager.RegisterDevice(deviceName, device, DeviceType),
-                   analogLowCutoff.Subscribe(newValue => {
-                       var regs = Rhs2116Config.AnalogLowCutoffToRegisters[newValue];
-                       var reg = regs[2] << 13 | regs[1] << 7 | regs[0];
-                       device.WriteRegister(Rhs2116.BW2, reg);
-                   }),
-                   analogLowCutoffRecovery.Subscribe(newValue => {
-                       var regs = Rhs2116Config.AnalogLowCutoffToRegisters[newValue];
-                       var reg = regs[2] << 13 | regs[1] << 7 | regs[0];
-                       device.WriteRegister(Rhs2116.BW3, reg);
-                   }),
-                   analogHighCutoff.Subscribe(newValue => {
-                       var regs = Rhs2116Config.AnalogHighCutoffToRegisters[newValue];
-                       device.WriteRegister(Rhs2116.BW0, regs[1] << 6 | regs[0]);
-                       device.WriteRegister(Rhs2116.BW1, regs[3] << 6 | regs[2]);
-                       device.WriteRegister(Rhs2116.FASTSETTLESAMPLES, Rhs2116Config.AnalogHighCutoffToFastSettleSamples[newValue]);
+                    DeviceManager.RegisterDevice(deviceName, device, DeviceType),
+                    analogLowCutoff.Subscribe(newValue => {
+                        var regs = Rhs2116Config.AnalogLowCutoffToRegisters[newValue];
+                        var reg = regs[2] << 13 | regs[1] << 7 | regs[0];
+                        device.WriteRegister(Rhs2116.BW2, reg);
+                    }),
+                    analogLowCutoffRecovery.Subscribe(newValue => {
+                        var regs = Rhs2116Config.AnalogLowCutoffToRegisters[newValue];
+                        var reg = regs[2] << 13 | regs[1] << 7 | regs[0];
+                        device.WriteRegister(Rhs2116.BW3, reg);
+                    }),
+                    analogHighCutoff.Subscribe(newValue => {
+                        var regs = Rhs2116Config.AnalogHighCutoffToRegisters[newValue];
+                        device.WriteRegister(Rhs2116.BW0, regs[1] << 6 | regs[0]);
+                        device.WriteRegister(Rhs2116.BW1, regs[3] << 6 | regs[2]);
+                        device.WriteRegister(Rhs2116.FASTSETTLESAMPLES, Rhs2116Config.AnalogHighCutoffToFastSettleSamples[newValue]);
+                    }),
+                    stimulusSequence.Subscribe(newValue => {
+
+
+                        // Step size
+                        var reg = Rhs2116Config.StimulatorStepSizeToRegisters[newValue.CurrentStepSize];
+                        device.WriteRegister(Rhs2116.STEPSZ, reg[2] << 13 | reg[1] << 7 | reg[0]);
+
+                        // Anodic amplitudes
+                        // TODO: cache last write and compare?
+                        var a = newValue.AnodicAmplitudes;
+                        for (int i = 0; i < a.Count(); i++)
+                        {
+                            device.WriteRegister(Rhs2116.POS00 + (uint)i, a.ElementAt(i));
+                        }
+
+                        // Cathodic amplitudes
+                        // TODO: cache last write and compare?
+                        var c = newValue.CathodicAmplitudes;
+                        for (int i = 0; i < a.Count(); i++)
+                        {
+                            device.WriteRegister(Rhs2116.NEG00 + (uint)i, c.ElementAt(i));
+                        }
+
+                        // Create delta table and set length
+                        var dt = newValue.DeltaTable;
+                        device.WriteRegister(Rhs2116.NUMDELTAS, (uint)dt.Count);
+
+                        // TODO: If we want to do this efficently, we probably need a different data structure on the
+                        // FPGA ram that allows columns to be out of order (e.g. linked list)
+                        uint j = 0;
+                        foreach (var d in dt)
+                        {
+                            uint indexAndTime = j++ << 22 | (d.Key & 0x003FFFFF);
+                            device.WriteRegister(Rhs2116.DELTAIDXTIME, indexAndTime);
+                            device.WriteRegister(Rhs2116.DELTAPOLEN, d.Value);
+                        }
                     })
-               );
+                );
             });
         }
     }
@@ -123,6 +169,7 @@ namespace OpenEphys.Onix
 
         // constants
         public const int AmplifierChannelCount = 16;
+        public const int StimMemorySlotsAvailable = 1024;
 
         // managed registers
         public const uint ENABLE = 0x8000; // Enable or disable the data output stream (32767)

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhs2116Trigger.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhs2116Trigger.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureRhs2116Trigger : SingleDeviceFactory
+    {
+        public ConfigureRhs2116Trigger()
+            : base(typeof(Rhs2116Trigger))
+        {
+        }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies whether the RHS2116 device is enabled.")]
+        public Rhs2116TriggerSource TriggerSource { get; set; } = Rhs2116TriggerSource.Local;
+
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            var triggerSource = TriggerSource;
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice(context =>
+            {
+                var device = context.GetDeviceContext(deviceAddress, Rhs2116Trigger.ID);
+                device.WriteRegister(Rhs2116Trigger.TRIGGERSOURCE, (uint)triggerSource);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+            });
+        }
+    }
+
+    static class Rhs2116Trigger
+    {
+        public const int ID = 32;
+
+        // managed registers
+        public const uint ENABLE = 0; // Writes and reads to ENABLE are ignored without error
+        public const uint TRIGGERSOURCE = 1; // The LSB is used to determine the trigger source
+        public const uint TRIGGER = 2; // Writing 0x1 to this register will trigger a stimulation sequence if the TRIGGERSOURCE is set to 0.
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(Rhs2116Trigger))
+            {
+            }
+        }
+    }
+
+    public enum Rhs2116TriggerSource
+    {
+        [Description("Respect local triggers (e.g. via GPIO or TRIGGER register) and broadcast via sync pin. ")]
+        Local = 0,
+        [Description("Receiver. Only resepct triggers received from sync pin")]
+        External = 1,
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64ElectricalStimulatorTrigger.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64ElectricalStimulatorTrigger.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class Headstage64ElectricalStimulatorTrigger: Sink<bool>
+    {
+        [TypeConverter(typeof(Headstage64ElectricalStimulator.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<bool> Process(IObservable<bool> source)
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var device = deviceInfo.GetDeviceContext(typeof(Headstage64ElectricalStimulator));
+                    return source.Do(t => device.WriteRegister(Headstage64ElectricalStimulator.TRIGGER, t ? 1u : 0u));
+                }));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhs2116Config.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhs2116Config.cs
@@ -1,0 +1,259 @@
+﻿using System.Collections.Generic;
+
+namespace OpenEphys.Onix
+{
+    public static class Rhs2116Config
+    {
+        public static readonly IReadOnlyDictionary<Rhs2116AnalogLowCutoff, IReadOnlyList<uint>> AnalogLowCutoffToRegisters =
+            new Dictionary<Rhs2116AnalogLowCutoff, IReadOnlyList<uint>>()
+        {
+            { Rhs2116AnalogLowCutoff.Low1000Hz, new uint[] { 10, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low500Hz, new uint[] { 13, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low300Hz, new uint[] { 15, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low250Hz, new uint[] { 17, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low200Hz, new uint[] { 18, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low150Hz, new uint[] { 21, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low100Hz, new uint[] { 25, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low75Hz, new uint[] { 28, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low50Hz, new uint[] { 34, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low30Hz, new uint[] { 44, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low25Hz, new uint[] { 48, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low20Hz, new uint[] { 54, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low15Hz, new uint[] { 62, 0, 0 } },
+            { Rhs2116AnalogLowCutoff.Low10Hz, new uint[] { 5, 1, 0 } },
+            { Rhs2116AnalogLowCutoff.Low7500mHz, new uint[] { 18, 1, 0 } },
+            { Rhs2116AnalogLowCutoff.Low5000mHz, new uint[] { 40, 1, 0 } },
+            { Rhs2116AnalogLowCutoff.Low3090mHz, new uint[] { 20, 2, 0 } },
+            { Rhs2116AnalogLowCutoff.Low2500mHz, new uint[] { 42, 2, 0 } },
+            { Rhs2116AnalogLowCutoff.Low2000mHz, new uint[] { 8, 3, 0 } },
+            { Rhs2116AnalogLowCutoff.Low1500mHz, new uint[] { 9, 4, 0 } },
+            { Rhs2116AnalogLowCutoff.Low1000mHz, new uint[] { 44, 6, 0 } },
+            { Rhs2116AnalogLowCutoff.Low750mHz, new uint[] { 49, 9, 0 } },
+            { Rhs2116AnalogLowCutoff.Low500mHz, new uint[] { 35, 17, 0 } },
+            { Rhs2116AnalogLowCutoff.Low300mHz, new uint[] { 1, 40, 0 } },
+            { Rhs2116AnalogLowCutoff.Low250mHz, new uint[] { 56, 54, 0 } },
+            { Rhs2116AnalogLowCutoff.Low100mHz, new uint[] { 16, 60, 1 } },
+        };
+
+        public static readonly IReadOnlyDictionary<Rhs2116AnalogHighCutoff, IReadOnlyList<uint>> AnalogHighCutoffToRegisters =
+            new Dictionary<Rhs2116AnalogHighCutoff, IReadOnlyList<uint>>()
+        {
+            { Rhs2116AnalogHighCutoff.High20000Hz, new uint[] { 8, 0, 4, 0 } },
+            { Rhs2116AnalogHighCutoff.High15000Hz, new uint[] { 11, 0, 8, 0 } },
+            { Rhs2116AnalogHighCutoff.High10000Hz, new uint[] { 17, 0, 16, 0 } },
+            { Rhs2116AnalogHighCutoff.High7500Hz, new uint[] { 22, 0, 23, 0 } },
+            { Rhs2116AnalogHighCutoff.High5000Hz, new uint[] { 33, 0, 37, 0 } },
+            { Rhs2116AnalogHighCutoff.High3000Hz, new uint[] { 3, 1, 13, 1 } },
+            { Rhs2116AnalogHighCutoff.High2500Hz, new uint[] { 13, 1, 25, 1 } },
+            { Rhs2116AnalogHighCutoff.High2000Hz, new uint[] { 27, 1, 44, 1 } },
+            { Rhs2116AnalogHighCutoff.High1500Hz, new uint[] { 1, 2, 23, 2 } },
+            { Rhs2116AnalogHighCutoff.High1000Hz, new uint[] { 46, 2, 30, 3 } },
+            { Rhs2116AnalogHighCutoff.High750Hz, new uint[] { 41, 3, 36, 4 } },
+            { Rhs2116AnalogHighCutoff.High500Hz, new uint[] { 30, 5, 43, 6 } },
+            { Rhs2116AnalogHighCutoff.High300Hz, new uint[] { 6, 9, 2, 11 } },
+            { Rhs2116AnalogHighCutoff.High250Hz, new uint[] { 42, 10, 5, 13 } },
+            { Rhs2116AnalogHighCutoff.High200Hz, new uint[] { 24, 13, 7, 16 } },
+            { Rhs2116AnalogHighCutoff.High150Hz, new uint[] { 44, 17, 8, 21 } },
+            { Rhs2116AnalogHighCutoff.High100Hz, new uint[] { 38, 26, 5, 31 } },
+        };
+
+        public static readonly IReadOnlyDictionary<Rhs2116AnalogHighCutoff, uint> AnalogHighCutoffToFastSettleSamples =
+            new Dictionary<Rhs2116AnalogHighCutoff, uint>()
+        {
+            { Rhs2116AnalogHighCutoff.High20000Hz, 4 },
+            { Rhs2116AnalogHighCutoff.High15000Hz, 5 },
+            { Rhs2116AnalogHighCutoff.High10000Hz, 8 },
+            { Rhs2116AnalogHighCutoff.High7500Hz, 10 },
+            { Rhs2116AnalogHighCutoff.High5000Hz, 15 },
+            { Rhs2116AnalogHighCutoff.High3000Hz, 25 },
+            { Rhs2116AnalogHighCutoff.High2500Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High2000Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High1500Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High1000Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High750Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High500Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High300Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High250Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High200Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High150Hz, 30 },
+            { Rhs2116AnalogHighCutoff.High100Hz, 30 },
+        };
+
+        public static readonly IReadOnlyDictionary<Rhs2116StepSize, IReadOnlyList<uint>> StimulatorStepSizeToRegisters =
+            new Dictionary<Rhs2116StepSize, IReadOnlyList<uint>>()
+        {
+            { Rhs2116StepSize.Step10nA, new uint[] { 64, 19, 3 } },
+            { Rhs2116StepSize.Step20nA, new uint[] { 40, 40, 1 } },
+            { Rhs2116StepSize.Step50nA, new uint[] { 64, 40, 0 } },
+            { Rhs2116StepSize.Step100nA, new uint[] { 30, 20, 0 } },
+            { Rhs2116StepSize.Step200nA, new uint[] { 25, 10, 0 } },
+            { Rhs2116StepSize.Step500nA, new uint[] { 101, 3, 0 } },
+            { Rhs2116StepSize.Step1000nA, new uint[] { 98, 1, 0 } },
+            { Rhs2116StepSize.Step2000nA, new uint[] { 94, 0, 0 } },
+            { Rhs2116StepSize.Step5000nA, new uint[] { 38, 0, 0 } },
+            {  Rhs2116StepSize.Step10000nA, new uint[] { 15, 0, 0 } },
+        };
+    }
+
+    public enum Rhs2116AnalogLowCutoff
+    {
+        Low1000Hz,
+        Low500Hz,
+        Low300Hz,
+        Low250Hz,
+        Low200Hz,
+        Low150Hz,
+        Low100Hz,
+        Low75Hz,
+        Low50Hz,
+        Low30Hz,
+        Low25Hz,
+        Low20Hz,
+        Low15Hz,
+        Low10Hz,
+        Low7500mHz,
+        Low5000mHz,
+        Low3090mHz,
+        Low2500mHz,
+        Low2000mHz,
+        Low1500mHz,
+        Low1000mHz,
+        Low750mHz,
+        Low500mHz,
+        Low300mHz,
+        Low250mHz,
+        Low100mHz,
+    }
+
+    public enum Rhs2116AnalogHighCutoff
+    {
+        High20000Hz,
+        High15000Hz,
+        High10000Hz,
+        High7500Hz,
+        High5000Hz,
+        High3000Hz,
+        High2500Hz,
+        High2000Hz,
+        High1500Hz,
+        High1000Hz,
+        High750Hz,
+        High500Hz,
+        High300Hz,
+        High250Hz,
+        High200Hz,
+        High150Hz,
+        High100Hz,
+    }
+
+
+
+    public enum Rhs2116DspCutoff
+    {
+        /// <summary>
+        /// out = samp[n] - samp[n-1]
+        /// </summary>
+        Differential = 0,
+
+        /// <summary>
+        /// 3309 Hz
+        /// </summary>
+        Dsp3309Hz,
+
+        /// <summary>
+        /// 1370 Hz
+        /// </summary>
+        Dsp1374Hz,
+        
+        /// <summary>
+        /// 638 Hz
+        /// </summary>
+        Dsp638Hz,
+        
+        /// <summary>
+        /// 308 Hz
+        /// </summary>
+        Dsp308Hz,
+        
+        /// <summary>
+        /// 152 Hz
+        /// </summary>
+        Dsp152Hz,
+        
+        /// <summary>
+        /// 75.2 Hz
+        /// </summary>
+        Dsp75Hz,
+        
+        /// <summary>
+        /// 37.4 Hz
+        /// </summary>
+        Dsp37Hz,
+        
+        /// <summary>
+        /// 18.7 Hz
+        /// </summary>
+        Dsp19Hz,
+        
+        /// <summary>
+        /// 9.34 Hz
+        /// </summary>
+        Dsp9336mHz,
+        
+        /// <summary>
+        /// 4.67 Hz
+        /// </summary>
+        Dsp4665mHz,
+        
+        /// <summary>
+        /// 2.33 Hz
+        /// </summary>
+        Dsp2332mHz,
+        
+        /// <summary>
+        /// 1.17 Hz
+        /// </summary>
+        Dsp1166mHz,
+        
+        /// <summary>
+        /// 0.583 Hz
+        /// </summary>
+        Dsp583mHz,
+        
+        /// <summary>
+        /// 0.291 Hz
+        /// </summary>
+        Dsp291mHz,
+        
+        /// <summary>
+        /// 0.146 Hz
+        /// </summary>
+        Dsp146mHz,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        Off
+    }
+
+    public enum Rhs2116StepSize
+    {
+        Step10nA,
+        Step20nA,
+        Step50nA,
+        Step100nA,
+        Step200nA,
+        Step500nA,
+        Step1000nA,
+        Step2000nA,
+        Step5000nA,
+        Step10000nA
+    }
+
+    // NB: DC data only provided in unsigned. Force amplifier data to use unsigned for consistency
+    //public enum Rhs2116AmplifierDataFormat
+    //{
+    //    Unsigned,
+    //    TwosComplement
+    //}
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhs2116Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhs2116Data.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Runtime.InteropServices;
+using Bonsai;
+using OpenCV.Net;
+
+namespace OpenEphys.Onix
+{
+    public class Rhs2116Data : Source<Rhs2116DataFrame>
+    {
+        [TypeConverter(typeof(Rhs2116.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public int BufferSize { get; set; } = 30;
+
+        public unsafe override IObservable<Rhs2116DataFrame> Generate()
+        {
+            var bufferSize = BufferSize;
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                    Observable.Create<Rhs2116DataFrame>(observer =>
+                    {
+                        var sampleIndex = 0;
+                        var device = deviceInfo.GetDeviceContext(typeof(Rhs2116));
+                        var amplifierBuffer = new short[Rhs2116.AmplifierChannelCount * bufferSize];
+                        var dcBuffer = new short[Rhs2116.AmplifierChannelCount * bufferSize];
+                        var hubClockBuffer = new ulong[bufferSize];
+                        var clockBuffer = new ulong[bufferSize];
+
+                        var frameObserver = Observer.Create<oni.Frame>(
+                            frame =>
+                            {
+                                var payload = (Rhs2116Payload*)frame.Data.ToPointer();
+                                Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, sampleIndex * Rhs2116.AmplifierChannelCount, Rhs2116.AmplifierChannelCount);
+                                Marshal.Copy(new IntPtr(payload->DCData), dcBuffer, sampleIndex * Rhs2116.AmplifierChannelCount, Rhs2116.AmplifierChannelCount);
+                                hubClockBuffer[sampleIndex] = BitHelper.SwapEndian(payload->HubClock);
+                                clockBuffer[sampleIndex] = frame.Clock;
+                                if (++sampleIndex >= bufferSize)
+                                {
+                                    var amplifierData = BufferHelper.CopyBuffer(amplifierBuffer, bufferSize, Rhs2116.AmplifierChannelCount, Depth.U16);
+                                    var dcData = BufferHelper.CopyBuffer(dcBuffer, bufferSize, Rhs2116.AmplifierChannelCount, Depth.U16);
+                                    observer.OnNext(new Rhs2116DataFrame(clockBuffer, hubClockBuffer, amplifierData, dcData));
+                                    hubClockBuffer = new ulong[bufferSize];
+                                    clockBuffer = new ulong[bufferSize];
+                                    sampleIndex = 0;
+                                }
+                            },
+                            observer.OnError,
+                            observer.OnCompleted);
+                        return deviceInfo.Context.FrameReceived
+                            .Where(frame => frame.DeviceAddress == device.Address)
+                            .SubscribeSafe(frameObserver);
+                    })));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhs2116DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhs2116DataFrame.cs
@@ -1,0 +1,32 @@
+﻿using System.Runtime.InteropServices;
+using OpenCV.Net;
+
+namespace OpenEphys.Onix
+{
+    public class Rhs2116DataFrame
+    {
+        public Rhs2116DataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, Mat dcData)
+        {
+            Clock = clock;
+            HubClock = hubClock;
+            AmplifierData = amplifierData;
+            DCData = dcData;
+        }
+
+        public ulong[] Clock { get; }
+
+        public ulong[] HubClock { get; }
+
+        public Mat AmplifierData { get; }
+
+        public Mat DCData { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct Rhs2116Payload
+    {
+        public ulong HubClock;
+        public fixed ushort AmplifierData[Rhs2116.AmplifierChannelCount];
+        public fixed ushort DCData[Rhs2116.AmplifierChannelCount];
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhs2116StimulusTrigger.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhs2116StimulusTrigger.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class Rhs2116StimulusTrigger : Sink<bool>
+    {
+        [TypeConverter(typeof(Rhs2116Trigger.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<bool> Process(IObservable<bool> source)
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var device = deviceInfo.GetDeviceContext(typeof(Rhs2116Trigger));
+                    return source.Do(t => device.WriteRegister(Rhs2116Trigger.TRIGGER, t ? 1u : 0u));
+                }));
+        }
+    }
+}


### PR DESCRIPTION
This commit contains partial support for headstage-rhs2116 32-channel bidirectional headstage. The stimulation configuration and delivery side of the equation is not yet implemented. Note that this headstage contains 2 RHS2116 chips and therefore #53 is relevant.