### PR TITLE
Support for NeuropixelsV2 BNO055

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -12,9 +12,9 @@ namespace OpenEphys.Onix
             var payload = (Bno055Payload*)frame.Data.ToPointer();
             HubClock = payload->HubClock;
             EulerAngle = new Vector3(
-                y: Bno055.EulerAngleScale * payload->EulerAngle[0],  // yaw
-                z: Bno055.EulerAngleScale * payload->EulerAngle[1],  // roll
-                x: Bno055.EulerAngleScale * payload->EulerAngle[2]); // pitch
+                x: Bno055.EulerAngleScale * payload->EulerAngle[0],  // yaw
+                y: Bno055.EulerAngleScale * payload->EulerAngle[1],  // roll
+                z: Bno055.EulerAngleScale * payload->EulerAngle[2]); // pitch
             Quaternion = new Quaternion(
                 w: Bno055.QuaternionScale * payload->Quaternion[0],
                 x: Bno055.QuaternionScale * payload->Quaternion[1],

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -21,9 +21,9 @@ namespace OpenEphys.Onix
         {
             Clock = clock;
             EulerAngle = new Vector3(
-                x: Bno055.EulerAngleScale * payload->EulerAngle[0],  // yaw
-                y: Bno055.EulerAngleScale * payload->EulerAngle[1],  // roll
-                z: Bno055.EulerAngleScale * payload->EulerAngle[2]); // pitch
+                x: Bno055.EulerAngleScale * payload->EulerAngle[0],
+                y: Bno055.EulerAngleScale * payload->EulerAngle[1],
+                z: Bno055.EulerAngleScale * payload->EulerAngle[2]);
             Quaternion = new Quaternion(
                 w: Bno055.QuaternionScale * payload->Quaternion[0],
                 x: Bno055.QuaternionScale * payload->Quaternion[1],

--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -7,10 +7,19 @@ namespace OpenEphys.Onix
     public class Bno055DataFrame
     {
         public unsafe Bno055DataFrame(oni.Frame frame)
+            : this(frame.Clock, (Bno055Payload*)frame.Data.ToPointer())
         {
-            Clock = frame.Clock;
-            var payload = (Bno055Payload*)frame.Data.ToPointer();
+        }
+
+        internal unsafe Bno055DataFrame(ulong clock, Bno055Payload* payload)
+            : this(clock, &payload->Data)
+        {
             HubClock = payload->HubClock;
+        }
+
+        internal unsafe Bno055DataFrame(ulong clock, Bno055DataPayload* payload)
+        {
+            Clock = clock;
             EulerAngle = new Vector3(
                 x: Bno055.EulerAngleScale * payload->EulerAngle[0],  // yaw
                 y: Bno055.EulerAngleScale * payload->EulerAngle[1],  // roll
@@ -53,6 +62,12 @@ namespace OpenEphys.Onix
     unsafe struct Bno055Payload
     {
         public ulong HubClock;
+        public Bno055DataPayload Data;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct Bno055DataPayload
+    {
         public fixed short EulerAngle[3];
         public fixed short Quaternion[4];
         public fixed short Acceleration[3];

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
@@ -53,7 +53,8 @@ namespace OpenEphys.Onix
                     ConfigureProbeStreaming(probeControl);
                 }
 
-                var disposable = DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
+                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
                 var shutdown = Disposable.Create(() =>
                 {
                     serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, NeuropixelsV2e.DefaultGPO10Config);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
@@ -77,7 +77,8 @@ namespace OpenEphys.Onix
                 // Still its good to get them roughly (i.e. within 10 PCLKs) started at the same time.
                 SyncProbes(serializer, gpo10Config);
 
-                var disposable = DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
+                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
                 var shutdown = Disposable.Create(() =>
                 {
                     serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, NeuropixelsV2eBeta.DefaultGPO10Config);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -20,6 +20,10 @@ namespace OpenEphys.Onix
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureNeuropixelsV2eBeta NeuropixelsV2Beta { get; set; } = new();
 
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureNeuropixelsV2eBno055 Bno055 { get; set; } = new();
+
         public PortName Port
         {
             get { return port; }
@@ -29,6 +33,7 @@ namespace OpenEphys.Onix
                 var offset = (uint)port << 8;
                 LinkController.DeviceAddress = (uint)port;
                 NeuropixelsV2Beta.DeviceAddress = offset + 0;
+                Bno055.DeviceAddress = offset + 1;
             }
         }
 
@@ -36,6 +41,7 @@ namespace OpenEphys.Onix
         {
             yield return LinkController;
             yield return NeuropixelsV2Beta;
+            yield return Bno055;
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
@@ -25,7 +25,8 @@ namespace OpenEphys.Onix
                 var device = context.GetPassthroughDeviceContext(deviceAddress, DS90UB9x.ID);
                 ConfigureDeserializer(device);
                 ConfigureBno055(device);
-                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+                var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);
+                return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureNeuropixelsV2eBno055 : SingleDeviceFactory
+    {
+        public ConfigureNeuropixelsV2eBno055()
+            : base(typeof(NeuropixelsV2eBno055))
+        {
+        }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies whether the BNO055 device is enabled.")]
+        public bool Enable { get; set; } = true;
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            var enable = Enable;
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice(context =>
+            {
+                // configure device via the DS90UB9x deserializer device
+                var device = context.GetPassthroughDeviceContext(deviceAddress, DS90UB9x.ID);
+                ConfigureDeserializer(device);
+                ConfigureBno055(device);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+            });
+        }
+
+        static void ConfigureDeserializer(DeviceContext device)
+        {
+            // configure deserializer I2C aliases
+            var deserializer = new I2CRegisterContext(device, DS90UB9x.DES_ADDR);
+            uint alias = NeuropixelsV2eBno055.BNO055Address << 1;
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveID4, alias);
+            deserializer.WriteByte((uint)DS90UB9xDeserializerI2CRegister.SlaveAlias4, alias);
+        }
+
+        static void ConfigureBno055(DeviceContext device)
+        {
+            // setup BNO055 device
+            var i2c = new I2CRegisterContext(device, NeuropixelsV2eBno055.BNO055Address);
+            i2c.WriteByte(0x3E, 0x00); // Power mode normal
+            i2c.WriteByte(0x07, 0x00); // Page ID address 0
+            i2c.WriteByte(0x3F, 0x00); // Internal oscillator
+            i2c.WriteByte(0x41, 0b00000110);  // Axis map config (configured to match hs64; X => Z, Y => -Y, Z => X)
+            i2c.WriteByte(0x42, 0b000000010); // Axis sign (negate Y)
+            i2c.WriteByte(0x3D, 8); // Operation mode is NOF
+        }
+    }
+
+    static class NeuropixelsV2eBno055
+    {
+        public const int BNO055Address = 0x28;
+        public const int DataAddress = 0x1A;
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(NeuropixelsV2eBno055))
+            {
+            }
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
@@ -20,6 +20,10 @@ namespace OpenEphys.Onix
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureNeuropixelsV2e NeuropixelsV2 { get; set; } = new();
 
+        [Category(ConfigurationCategory)]
+        [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureNeuropixelsV2eBno055 Bno055 { get; set; } = new();
+
         public PortName Port
         {
             get { return port; }
@@ -29,6 +33,7 @@ namespace OpenEphys.Onix
                 var offset = (uint)port << 8;
                 LinkController.DeviceAddress = (uint)port;
                 NeuropixelsV2.DeviceAddress = offset + 0;
+                Bno055.DeviceAddress = offset + 1;
             }
         }
 
@@ -36,6 +41,7 @@ namespace OpenEphys.Onix
         {
             yield return LinkController;
             yield return NeuropixelsV2;
+            yield return Bno055;
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextHelper.cs
@@ -38,5 +38,10 @@ namespace OpenEphys.Onix
             var passthroughDeviceAddress = context.GetPassthroughDeviceAddress(address);
             return GetDeviceContext(context, passthroughDeviceAddress, id);
         }
+
+        public static DeviceContext GetPassthroughDeviceContext(this DeviceContext device, int id)
+        {
+            return GetPassthroughDeviceContext(device.Context, device.Address, id);
+        }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -351,7 +351,7 @@ namespace OpenEphys.Onix
 
         public oni.Frame ReadFrame()
         {
-            lock (regLock)
+            lock (readLock)
             {
                 return ctx.ReadFrame();
             }

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -38,18 +38,16 @@ namespace OpenEphys.Onix
         event Func<ContextTask, IDisposable> configureDevice;
 
         // NOTE: There was a GC memory leak around here
-        internal Subject<oni.Frame> FrameReceived = new Subject<oni.Frame>();
+        internal Subject<oni.Frame> FrameReceived = new();
 
         public static readonly string DefaultDriver = "riffa";
         public static readonly int DefaultIndex = 0;
 
         // TODO: These work for RIFFA implementation, but potentially not others!!
-        private readonly object readLock = new object();
-        private readonly object writeLock = new object();
-        private readonly object regLock = new object();
-
+        private readonly object readLock = new();
+        private readonly object writeLock = new();
+        private readonly object regLock = new();
         private bool running = false;
-        private readonly object runLock = new object();
 
         private readonly string contextDriver = DefaultDriver;
         private readonly int contextIndex = DefaultIndex;
@@ -73,16 +71,15 @@ namespace OpenEphys.Onix
 
         public void Reset()
         {
-            lock (runLock)
+            lock (regLock)
             {
                 Stop();
                 lock (readLock)
                     lock (writeLock)
-                        lock (regLock)
-                        {
-                            ctx?.Dispose();
-                            Initialize();
-                        }
+                    {
+                        ctx?.Dispose();
+                        Initialize();
+                    }
             }
         }
 
@@ -155,7 +152,7 @@ namespace OpenEphys.Onix
 
         internal void Start()
         {
-            lock (runLock)
+            lock (regLock)
             {
                 if (running) return;
 
@@ -240,7 +237,7 @@ namespace OpenEphys.Onix
 
         internal void Stop()
         {
-            lock (runLock)
+            lock (regLock)
             {
                 if (!running) return;
                 if ((distributeFrames != null || readFrames != null) && !distributeFrames.IsCanceled)
@@ -395,15 +392,14 @@ namespace OpenEphys.Onix
 
         public void Dispose()
         {
-            lock (runLock)
+            lock (regLock)
             {
                 Stop();
                 lock (readLock)
                     lock (writeLock)
-                        lock (regLock)
-                        {
-                            ctx?.Dispose();
-                        }
+                    {
+                        ctx?.Dispose();
+                    }
             }
 
             GC.SuppressFinalize(this);

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -325,6 +325,17 @@ namespace OpenEphys.Onix
             }
         }
 
+        // NB: This is for actions that require synchronized register access and might
+        // be called asynchronously with context dispose
+        internal void EnsureContext(Action action)
+        {
+            lock (regLock)
+            {
+                if (ctx != null)
+                    action();
+            }
+        }
+
         internal uint ReadRegister(uint deviceAddress, uint registerAddress)
         {
             lock (regLock)
@@ -399,6 +410,7 @@ namespace OpenEphys.Onix
                     lock (writeLock)
                     {
                         ctx?.Dispose();
+                        ctx = null;
                     }
             }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -58,12 +58,7 @@ namespace OpenEphys.Onix
         {
             contextDriver = driver;
             contextIndex = index;
-            lock (readLock)
-                lock (writeLock)
-                    lock (regLock)
-                    {
-                        Initialize();
-                    }
+            Initialize();
         }
 
         private void Initialize()

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
@@ -25,8 +25,9 @@ namespace OpenEphys.Onix
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
                     var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV2eBeta));
-                    var probeData = deviceInfo.Context.FrameReceived.Where(frame =>
-                        frame.DeviceAddress == device.Address &&
+                    var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                    var probeData = device.Context.FrameReceived.Where(frame =>
+                        frame.DeviceAddress == passthrough.Address &&
                         NeuropixelsV2eBetaDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
                     return Observable.Create<NeuropixelsV2eBetaDataFrame>(observer =>
                     {

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class NeuropixelsV2eBno055Data : Source<Bno055DataFrame>
+    {
+        [TypeConverter(typeof(NeuropixelsV2eBno055.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<Bno055DataFrame> Generate()
+        {
+            // Max of 100 Hz, but limited by I2C bus
+            var source = Observable.Interval(TimeSpan.FromSeconds(0.01));
+            return Generate(source);
+        }
+
+        public unsafe IObservable<Bno055DataFrame> Generate<TSource>(IObservable<TSource> source)
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(
+                    deviceInfo => Observable.Create<Bno055DataFrame>(observer =>
+                    {
+                        var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV2eBno055));
+                        var i2c = new I2CRegisterContext(device, NeuropixelsV2eBno055.BNO055Address);
+
+                        var pollingObserver = Observer.Create<TSource>(
+                            _ =>
+                            {
+                                var data = i2c.ReadBytes(NeuropixelsV2eBno055.DataAddress, sizeof(Bno055DataPayload));
+                                ulong clock = device.ReadRegister(DS90UB9x.LASTI2CL);
+                                clock += (ulong)device.ReadRegister(DS90UB9x.LASTI2CH) << 32;
+                                Bno055DataFrame frame;
+                                fixed (byte* dataPtr = data)
+                                {
+                                    frame = new Bno055DataFrame(clock, (Bno055DataPayload*)dataPtr);
+                                }
+                                observer.OnNext(frame);
+                            },
+                            observer.OnError,
+                            observer.OnCompleted);
+                        return source.SubscribeSafe(pollingObserver);
+                    })));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
@@ -27,14 +27,15 @@ namespace OpenEphys.Onix
                     deviceInfo => Observable.Create<Bno055DataFrame>(observer =>
                     {
                         var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV2eBno055));
-                        var i2c = new I2CRegisterContext(device, NeuropixelsV2eBno055.BNO055Address);
+                        var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                        var i2c = new I2CRegisterContext(passthrough, NeuropixelsV2eBno055.BNO055Address);
 
                         var pollingObserver = Observer.Create<TSource>(
                             _ =>
                             {
                                 var data = i2c.ReadBytes(NeuropixelsV2eBno055.DataAddress, sizeof(Bno055DataPayload));
-                                ulong clock = device.ReadRegister(DS90UB9x.LASTI2CL);
-                                clock += (ulong)device.ReadRegister(DS90UB9x.LASTI2CH) << 32;
+                                ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
+                                clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;
                                 Bno055DataFrame frame;
                                 fixed (byte* dataPtr = data)
                                 {

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
@@ -25,8 +25,9 @@ namespace OpenEphys.Onix
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
                     var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV2e));
-                    var probeData = deviceInfo.Context.FrameReceived.Where(frame =>
-                        frame.DeviceAddress == device.Address &&
+                    var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                    var probeData = device.Context.FrameReceived.Where(frame =>
+                        frame.DeviceAddress == passthrough.Address &&
                         NeuropixelsV2eDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
                     return Observable.Create<NeuropixelsV2eDataFrame>(observer =>
                     {


### PR DESCRIPTION
This PR adds configuration and streaming operators for the BNO055 sensor on NeuropixelsV2 headstages, both beta and non-beta versions. The active polling I2C interface required solving multiple synchronization issues at both the software and kernel driver levels. The current solution requires the latest kernel driver 6.1.0.2 to operate correctly.

To allow reuse in both beta and non-beta headstages, the sensor configuration was abstracted by using a new option for registering virtual passthrough devices exposed via the raw DS90UB9X serializer interface. This is not meant as a long-term solution and is expected to remain internal.

`ContextTask` was refactored to allow for "transactions", i.e. block operations on device registers where there is a guarantee that the device context will not be asynchronously disposed mid-transaction. The transaction is cancelled if the device has been disposed upon entering the register lock.

Fixes #38 