### PR TITLE
Allow dispose action on configure link and host

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -78,12 +78,13 @@ namespace OpenEphys.Onix
                     }
                 }
 
+                void dispose() => device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
                 if (!hasLock)
                 {
-                    device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
+                    dispose();
                     throw new InvalidOperationException("Unable to get SERDES lock on FMC link controller.");
                 }
-                return Disposable.Empty;
+                return Disposable.Create(dispose);
             })
             .ConfigureDevice(context => 
             {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Reactive.Disposables;
 using System.Threading;
 
 namespace OpenEphys.Onix
@@ -48,6 +49,7 @@ namespace OpenEphys.Onix
                 var portShift = ((int)deviceAddress - 1) * 2;
                 var passthroughState = (hubConfiguration == HubConfiguration.Passthrough ? 1 : 0) << portShift;
                 context.HubState = (PassthroughState)(((int)context.HubState & ~(1 << portShift)) | passthroughState);
+                return Disposable.Empty;
             })
             .ConfigureLink(context =>
             {
@@ -81,6 +83,7 @@ namespace OpenEphys.Onix
                     device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
                     throw new InvalidOperationException("Unable to get SERDES lock on FMC link controller.");
                 }
+                return Disposable.Empty;
             })
             .ConfigureDevice(context => 
             {

--- a/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
@@ -5,12 +5,12 @@ namespace OpenEphys.Onix
 {
     internal static class ObservableExtensions
     {
-        public static IObservable<ContextTask> ConfigureHost(this IObservable<ContextTask> source, Action<ContextTask> action)
+        public static IObservable<ContextTask> ConfigureHost(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> action)
         {
             return source.Do(context => context.ConfigureHost(action));
         }
 
-        public static IObservable<ContextTask> ConfigureLink(this IObservable<ContextTask> source, Action<ContextTask> action)
+        public static IObservable<ContextTask> ConfigureLink(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> action)
         {
             return source.Do(context => context.ConfigureLink(action));
         }


### PR DESCRIPTION
This PR refactors context initialization semantics to allow specifying dispose actions for host and link configuration. `ConfigureFmcLinkController` class is refactored to set port voltage to zero on either cancellation or exceptional termination of the acquisition sequence.

Fixes #47 