### PR TITLE
Update FmcLinkController port voltage algorithm

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -1,19 +1,25 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading;
 
 namespace OpenEphys.Onix
 {
     public class ConfigureHeadstage64 : HubDeviceFactory
     {
         PortName port;
-        readonly ConfigureFmcLinkController LinkController = new();
+        readonly ConfigureHeadstage64LinkController LinkController = new();
 
         public ConfigureHeadstage64()
         {
+            // TODO: The issue with this headstage is that its locking voltage is far, far lower than the voltage required for full
+            // functionality. Locking occurs at around 2V on the headstage (enough to turn 1.8V on). Full functionality is at 5.0 volts.
+            // Whats worse: the port voltage can only go down to 3.3V, which means that its very hard to find the true lowest voltage
+            // for a lock and then add a large offset to that.
             Port = PortName.PortA;
             LinkController.HubConfiguration = HubConfiguration.Standard;
-            LinkController.MinVoltage = 5.0;
-            LinkController.MaxVoltage = 7.0;
+            LinkController.MinVoltage = 3.3;
+            LinkController.MaxVoltage = 6.0;
+            LinkController.VoltageOffset = 3.4;
         }
 
         [Category(ConfigurationCategory)]
@@ -48,6 +54,23 @@ namespace OpenEphys.Onix
             yield return Rhd2164;
             yield return Bno055;
             yield return TS4231;
+        }
+
+        class ConfigureHeadstage64LinkController : ConfigureFmcLinkController
+        {
+            protected override void SetPortVoltage(DeviceContext device, uint voltage)
+            {
+                // TODO: It takes a huge amount of time to get to 0, almost 10 seconds.
+                // The best we can do at the moment is drive port voltage to minimum which
+                // is an active process and then settle from there to zero volts.
+                const int WaitUntilVoltageOffSettles = 4000;
+                const int WaitUntilVoltageOnSettles = 100;
+                device.WriteRegister(FmcLinkController.PORTVOLTAGE, 33);
+                device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
+                Thread.Sleep(WaitUntilVoltageOffSettles);
+                device.WriteRegister(FmcLinkController.PORTVOLTAGE, voltage);
+                Thread.Sleep(WaitUntilVoltageOnSettles);
+            }
         }
     }
 


### PR DESCRIPTION
- Expose more parameters of its operation
- Final link check after setting offset voltage
- From testing it was found that headstage-64 needs a very large amount of time to reach an acceptable voltage level to be considered off (nearly 10 seconds)
- A new virtual SetPortVoltage method was introduced in the base link controller to allow headstages to change the procedure depending on its needs. In the case of headstage-64, a two-step procedure with a long wait time after turning port voltage off, and a very large offset voltage applied after lock.

Fixes #64 