### PR TITLE
Refactor link controller as abstract base class

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -6,14 +6,12 @@ namespace OpenEphys.Onix
     public class ConfigureNeuropixelsV2eBetaHeadstage : HubDeviceFactory
     {
         PortName port;
-        readonly ConfigureFmcLinkController LinkController = new();
+        readonly ConfigureNeuropixelsV2eLinkController LinkController = new();
 
         public ConfigureNeuropixelsV2eBetaHeadstage()
         {
             Port = PortName.PortA;
             LinkController.HubConfiguration = HubConfiguration.Passthrough;
-            LinkController.MinVoltage = 5.0;
-            LinkController.MaxVoltage = 7.0;
         }
 
         [Category(ConfigurationCategory)]

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
@@ -6,14 +6,12 @@ namespace OpenEphys.Onix
     public class ConfigureNeuropixelsV2eHeadstage : HubDeviceFactory
     {
         PortName port;
-        readonly ConfigureFmcLinkController LinkController = new();
+        readonly ConfigureNeuropixelsV2eLinkController LinkController = new();
 
         public ConfigureNeuropixelsV2eHeadstage()
         {
             Port = PortName.PortA;
             LinkController.HubConfiguration = HubConfiguration.Passthrough;
-            LinkController.MinVoltage = 5.0;
-            LinkController.MaxVoltage = 7.0;
         }
 
         [Category(ConfigurationCategory)]

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eLinkController.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading;
+
+namespace OpenEphys.Onix
+{
+    class ConfigureNeuropixelsV2eLinkController : ConfigureFmcLinkController
+    {
+        protected override bool ConfigurePortVoltage(DeviceContext device)
+        {
+            const uint MinVoltage = 50;
+            const uint MaxVoltage = 70;
+            const uint VoltageOffset = 02;
+            const uint VoltageIncrement = 02;
+
+            for (uint voltage = MinVoltage; voltage <= MaxVoltage; voltage += VoltageIncrement)
+            {
+                SetPortVoltage(device, voltage);
+                if (CheckLinkState(device))
+                {
+                    SetPortVoltage(device, voltage + VoltageOffset);
+                    return CheckLinkState(device);
+                }
+            }
+
+            return false;
+        }
+
+        private void SetPortVoltage(DeviceContext device, uint voltage)
+        {
+            const int WaitUntilVoltageSettles = 200;
+            device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
+            Thread.Sleep(WaitUntilVoltageSettles);
+            device.WriteRegister(FmcLinkController.PORTVOLTAGE, voltage);
+            Thread.Sleep(WaitUntilVoltageSettles);
+        }
+    }
+}


### PR DESCRIPTION
This PR refactors the FMC link controller as an abstract base class to allow for maximum flexibility and isolation of headstage port voltage scanning implementations. Hub link controllers will now be required to provide their own implementations by overriding `ConfigurePortVoltage`. A helper function for checking the link state is provided in `CheckLinkState`.

Two reference implementations for HS64 and NeuropixelsV2e probes are provided.

Fixes #64 