### PR TITLE
Redirect initialization and dispose errors

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -93,23 +93,23 @@ namespace OpenEphys.Onix
 
         // NB: This is where actions that reconfigure the hub state, or otherwise
         // change the device table should be executed
-        internal void ConfigureHost(Func<ContextTask, IDisposable> action)
+        internal void ConfigureHost(Func<ContextTask, IDisposable> configure)
         {
-            configureHost += action;
+            configureHost += configure;
         }
 
         // NB: This is where actions that calibrate port voltage or otherwise
         // check link lock state should be executed
-        internal void ConfigureLink(Func<ContextTask, IDisposable> action)
+        internal void ConfigureLink(Func<ContextTask, IDisposable> configure)
         {
-            configureLink += action;
+            configureLink += configure;
         }
 
         // NB: Actions queued using this method should assume that the device table
         // is finalized and cannot be changed
-        internal void ConfigureDevice(Func<ContextTask, IDisposable> selector)
+        internal void ConfigureDevice(Func<ContextTask, IDisposable> configure)
         {
-            configureDevice += selector;
+            configureDevice += configure;
         }
 
         private IDisposable ConfigureContext()

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceManager.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceManager.cs
@@ -24,8 +24,9 @@ namespace OpenEphys.Onix
                 var subject = disposable.Subject;
                 if (subject.IsCompleted)
                 {
-                    throw new InvalidOperationException(
-                        "A device with the same name has already been configured."
+                    throw new ArgumentException(
+                        $"A device with the same name '{name}' has already been configured.",
+                        nameof(name)
                     );
                 }
 
@@ -39,8 +40,11 @@ namespace OpenEphys.Onix
                     var info = entry.Value.Subject.GetResult();
                     if (info.Context == deviceInfo.Context && info.DeviceAddress == deviceInfo.DeviceAddress)
                     {
-                        throw new InvalidOperationException(
-                            "A device with the same address has already been configured in this context."
+                        throw new ArgumentException(
+                            $"The specified device '{deviceInfo.DeviceType.Name}' could not be registered " +
+                            $"because another device '{info.DeviceType.Name}' with the same address " +
+                            $"{info.DeviceAddress} has already been configured in this context.",
+                            nameof(deviceInfo)
                         );
                     }
                 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
@@ -7,28 +7,36 @@ namespace OpenEphys.Onix
 {
     internal static class ObservableExtensions
     {
-        public static IObservable<ContextTask> ConfigureHost(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> action)
+        public static IObservable<ContextTask> ConfigureHost(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
         {
-            return source.Do(context => context.ConfigureHost(action));
+            return source.ConfigureContext((context, action) => context.ConfigureHost(action), configure);
         }
 
-        public static IObservable<ContextTask> ConfigureLink(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> action)
+        public static IObservable<ContextTask> ConfigureLink(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
         {
-            return source.Do(context => context.ConfigureLink(action));
+            return source.ConfigureContext((context, action) => context.ConfigureLink(action), configure);
         }
 
-        public static IObservable<ContextTask> ConfigureDevice(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> selector)
+        public static IObservable<ContextTask> ConfigureDevice(this IObservable<ContextTask> source, Func<ContextTask, IDisposable> configure)
+        {
+            return source.ConfigureContext((context, action) => context.ConfigureDevice(action), configure);
+        }
+
+        static IObservable<ContextTask> ConfigureContext(
+            this IObservable<ContextTask> source,
+            Action<ContextTask, Func<ContextTask, IDisposable>> configureContext,
+            Func<ContextTask, IDisposable> configure)
         {
             return Observable.Create<ContextTask>(observer =>
             {
                 var contextObserver = Observer.Create<ContextTask>(
                     context =>
                     {
-                        context.ConfigureDevice(ctx =>
+                        configureContext(context, ctx =>
                         {
                             try
                             {
-                                var disposable = selector(ctx);
+                                var disposable = configure(ctx);
                                 return Disposable.Create(() =>
                                 {
                                     try { disposable.Dispose(); }


### PR DESCRIPTION
Current device configuration uses deferred execution to allow functional composition of the initialization pipeline, which is then actually executed at `StartAcquisition`. This makes propagation of errors unintuitive since any exceptions are routed via the `StartAcquisition` node, no matter which step in the configuration chain they actually originated from.

This PR rewrites observable configuration operators so that on subscription they store the original observer in the configuration closure, and make sure any exceptions are routed there. This allows highlighting the correct node for any exceptions in the chain.

Fixes #69 