### PR TITLE
Rename hub clock to hub sync counter

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055DataFrame.cs
@@ -14,7 +14,7 @@ namespace OpenEphys.Onix
         internal unsafe Bno055DataFrame(ulong clock, Bno055Payload* payload)
             : this(clock, &payload->Data)
         {
-            HubClock = payload->HubClock;
+            HubSyncCounter = payload->HubSyncCounter;
         }
 
         internal unsafe Bno055DataFrame(ulong clock, Bno055DataPayload* payload)
@@ -43,7 +43,7 @@ namespace OpenEphys.Onix
 
         public ulong Clock { get; }
 
-        public ulong HubClock { get; }
+        public ulong HubSyncCounter { get; }
 
         public Vector3 EulerAngle { get; }
 
@@ -61,7 +61,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct Bno055Payload
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public Bno055DataPayload Data;
     }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputDataFrame.cs
@@ -8,13 +8,13 @@ namespace OpenEphys.Onix
         {
             Clock = frame.Clock;
             var payload = (HarpSyncInputPayload*)frame.Data.ToPointer();
-            HubClock = payload->HubClock;
+            HubSyncCounter = payload->HubSyncCounter;
             HarpTime = payload->HarpTime;
         }
 
         public ulong Clock { get; }
 
-        public ulong HubClock { get; }
+        public ulong HubSyncCounter { get; }
 
         public uint HarpTime { get; }
     }
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct HarpSyncInputPayload
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public uint HarpTime;
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/MemoryUsageDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/MemoryUsageDataFrame.cs
@@ -11,7 +11,7 @@ namespace OpenEphys.Onix
 
             FrameClock = frame.Clock;
             DeviceAddress = frame.DeviceAddress;
-            HubClock = payload->HubClock;
+            HubSyncCounter = payload->HubSyncCounter;
             PercentUsed = 100.0 * payload->Usage / totalMemory;
             BytesUsed = payload->Usage * 4;
 
@@ -21,7 +21,7 @@ namespace OpenEphys.Onix
 
         public uint DeviceAddress { get; private set; }
 
-        public ulong HubClock { get; }
+        public ulong HubSyncCounter { get; }
 
         public double PercentUsed { get; }
 
@@ -31,7 +31,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct MemoryUsagePayload
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public uint Usage;
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
@@ -34,7 +34,7 @@ namespace OpenEphys.Onix
                         var sampleIndex = 0;
                         var amplifierBuffer = new ushort[NeuropixelsV2eBeta.ChannelCount, bufferSize];
                         var frameCounter = new int[NeuropixelsV2eBeta.FramesPerSuperFrame * bufferSize];
-                        var hubClockBuffer = new ulong[bufferSize];
+                        var hubSyncCounterBuffer = new ulong[bufferSize];
                         var clockBuffer = new ulong[bufferSize];
 
                         var frameObserver = Observer.Create<oni.Frame>(
@@ -42,19 +42,19 @@ namespace OpenEphys.Onix
                             {
                                 var payload = (NeuropixelsV2BetaPayload*)frame.Data.ToPointer();
                                 NeuropixelsV2eBetaDataFrame.CopyAmplifierBuffer(payload->SuperFrame, amplifierBuffer, frameCounter, sampleIndex);
-                                hubClockBuffer[sampleIndex] = payload->HubClock;
+                                hubSyncCounterBuffer[sampleIndex] = payload->HubSyncCounter;
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
                                     var amplifierData = Mat.FromArray(amplifierBuffer);
                                     var dataFrame = new NeuropixelsV2eBetaDataFrame(
                                         clockBuffer,
-                                        hubClockBuffer,
+                                        hubSyncCounterBuffer,
                                         amplifierData,
                                         frameCounter);
                                     observer.OnNext(dataFrame);
                                     frameCounter = new int[NeuropixelsV2eBeta.FramesPerSuperFrame * bufferSize];
-                                    hubClockBuffer = new ulong[bufferSize];
+                                    hubSyncCounterBuffer = new ulong[bufferSize];
                                     clockBuffer = new ulong[bufferSize];
                                     sampleIndex = 0;
                                 }

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaDataFrame.cs
@@ -5,17 +5,17 @@ namespace OpenEphys.Onix
 {
     public class NeuropixelsV2eBetaDataFrame
     {
-        public NeuropixelsV2eBetaDataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, int[] frameCounter)
+        public NeuropixelsV2eBetaDataFrame(ulong[] clock, ulong[] hubSyncCounter, Mat amplifierData, int[] frameCounter)
         {
             Clock = clock;
-            HubClock = hubClock;
+            HubSyncCounter = hubSyncCounter;
             AmplifierData = amplifierData;
             FrameCounter = frameCounter;
         }
 
         public ulong[] Clock { get; }
 
-        public ulong[] HubClock { get; }
+        public ulong[] HubSyncCounter { get; }
 
         public Mat AmplifierData { get; }
 
@@ -81,7 +81,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct NeuropixelsV2BetaPayload
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public ushort ProbeIndex;
         public uint Reserved;
         public fixed ushort SuperFrame[NeuropixelsV2eBeta.FramesPerSuperFrame * NeuropixelsV2eBeta.FrameWords];

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
@@ -33,7 +33,7 @@ namespace OpenEphys.Onix
                     {
                         var sampleIndex = 0;
                         var amplifierBuffer = new ushort[NeuropixelsV2e.ChannelCount, bufferSize];
-                        var hubClockBuffer = new ulong[bufferSize];
+                        var hubSyncCounterBuffer = new ulong[bufferSize];
                         var clockBuffer = new ulong[bufferSize];
 
                         var frameObserver = Observer.Create<oni.Frame>(
@@ -41,13 +41,13 @@ namespace OpenEphys.Onix
                             {
                                 var payload = (NeuropixelsV2Payload*)frame.Data.ToPointer();
                                 NeuropixelsV2eDataFrame.CopyAmplifierBuffer(payload->AmplifierData, amplifierBuffer, sampleIndex);
-                                hubClockBuffer[sampleIndex] = payload->HubClock;
+                                hubSyncCounterBuffer[sampleIndex] = payload->HubSyncCounter;
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
                                     var amplifierData = Mat.FromArray(amplifierBuffer);
-                                    observer.OnNext(new NeuropixelsV2eDataFrame(clockBuffer, hubClockBuffer, amplifierData));
-                                    hubClockBuffer = new ulong[bufferSize];
+                                    observer.OnNext(new NeuropixelsV2eDataFrame(clockBuffer, hubSyncCounterBuffer, amplifierData));
+                                    hubSyncCounterBuffer = new ulong[bufferSize];
                                     clockBuffer = new ulong[bufferSize];
                                     sampleIndex = 0;
                                 }

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eDataFrame.cs
@@ -5,16 +5,16 @@ namespace OpenEphys.Onix
 {
     public class NeuropixelsV2eDataFrame
     {
-        public NeuropixelsV2eDataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData)
+        public NeuropixelsV2eDataFrame(ulong[] clock, ulong[] hubSyncCounter, Mat amplifierData)
         {
             Clock = clock;
-            HubClock = hubClock;
+            HubSyncCounter = hubSyncCounter;
             AmplifierData = amplifierData;
         }
 
         public ulong[] Clock { get; }
 
-        public ulong[] HubClock { get; }
+        public ulong[] HubSyncCounter { get; }
 
         public Mat AmplifierData { get; }
 
@@ -93,7 +93,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct NeuropixelsV2Payload
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public ushort ProbeIndex;
         public ulong Reserved;
         public fixed ushort AmplifierData[NeuropixelsV2e.ChannelCount];

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -28,7 +28,7 @@ namespace OpenEphys.Onix
                         var device = deviceInfo.GetDeviceContext(typeof(Rhd2164));
                         var amplifierBuffer = new short[Rhd2164.AmplifierChannelCount * bufferSize];
                         var auxBuffer = new short[Rhd2164.AuxChannelCount * bufferSize];
-                        var hubClockBuffer = new ulong[bufferSize];
+                        var hubSyncCounterBuffer = new ulong[bufferSize];
                         var clockBuffer = new ulong[bufferSize];
 
                         var frameObserver = Observer.Create<oni.Frame>(
@@ -37,14 +37,14 @@ namespace OpenEphys.Onix
                                 var payload = (Rhd2164Payload*)frame.Data.ToPointer();
                                 Marshal.Copy(new IntPtr(payload->AmplifierData), amplifierBuffer, sampleIndex * Rhd2164.AmplifierChannelCount, Rhd2164.AmplifierChannelCount);
                                 Marshal.Copy(new IntPtr(payload->AuxData), auxBuffer, sampleIndex * Rhd2164.AuxChannelCount, Rhd2164.AuxChannelCount);
-                                hubClockBuffer[sampleIndex] = payload->HubClock;
+                                hubSyncCounterBuffer[sampleIndex] = payload->HubSyncCounter;
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
                                     var amplifierData = BufferHelper.CopyBuffer(amplifierBuffer, bufferSize, Rhd2164.AmplifierChannelCount, Depth.U16);
                                     var auxData = BufferHelper.CopyBuffer(auxBuffer, bufferSize, Rhd2164.AuxChannelCount, Depth.U16);
-                                    observer.OnNext(new Rhd2164DataFrame(clockBuffer, hubClockBuffer, amplifierData, auxData));
-                                    hubClockBuffer = new ulong[bufferSize];
+                                    observer.OnNext(new Rhd2164DataFrame(clockBuffer, hubSyncCounterBuffer, amplifierData, auxData));
+                                    hubSyncCounterBuffer = new ulong[bufferSize];
                                     clockBuffer = new ulong[bufferSize];
                                     sampleIndex = 0;
                                 }

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164DataFrame.cs
@@ -5,17 +5,17 @@ namespace OpenEphys.Onix
 {
     public class Rhd2164DataFrame
     {
-        public Rhd2164DataFrame(ulong[] clock, ulong[] hubClock, Mat amplifierData, Mat auxData)
+        public Rhd2164DataFrame(ulong[] clock, ulong[] hubSyncCounter, Mat amplifierData, Mat auxData)
         {
             Clock = clock;
-            HubClock = hubClock;
+            HubSyncCounter = hubSyncCounter;
             AmplifierData = amplifierData;
             AuxData = auxData;
         }
 
         public ulong[] Clock { get; }
 
-        public ulong[] HubClock { get; }
+        public ulong[] HubSyncCounter { get; }
 
         public Mat AmplifierData { get; }
 
@@ -25,7 +25,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct Rhd2164Payload
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public fixed ushort AmplifierData[Rhd2164.AmplifierChannelCount];
         public fixed ushort AuxData[Rhd2164.AuxChannelCount];
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231DataFrame.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix
         {
             Clock = frame.Clock;
             var payload = (TS4231Payload*)frame.Data.ToPointer();
-            HubClock = payload->HubClock;
+            HubSyncCounter = payload->HubSyncCounter;
             SensorIndex = payload->SensorIndex;
             EnvelopeWidth = payload->EnvelopeWidth;
             EnvelopeType = payload->EnvelopeType;
@@ -16,7 +16,7 @@ namespace OpenEphys.Onix
 
         public ulong Clock { get; }
 
-        public ulong HubClock { get; }
+        public ulong HubSyncCounter { get; }
 
         public int SensorIndex { get; }
 
@@ -28,7 +28,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct TS4231Payload
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public ushort SensorIndex;
         public uint EnvelopeWidth;
         public TS4231Envelope EnvelopeType;

--- a/OpenEphys.Onix/OpenEphys.Onix/Test0Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Test0Data.cs
@@ -36,7 +36,7 @@ namespace OpenEphys.Onix
                     var sampleIndex = 0;
                     var dummyBuffer = new short[dummyWords * bufferSize];
                     var messageBuffer = new short[bufferSize];
-                    var hubClockBuffer = new ulong[bufferSize];
+                    var hubSyncCounterBuffer = new ulong[bufferSize];
                     var clockBuffer = new ulong[bufferSize];
 
                     var frameObserver = Observer.Create<oni.Frame>(
@@ -45,14 +45,14 @@ namespace OpenEphys.Onix
                             var payload = (Test0PayloadHeader*)frame.Data.ToPointer();
                             Marshal.Copy(new IntPtr(payload + 1), dummyBuffer, sampleIndex * dummyWords, dummyWords);
                             messageBuffer[sampleIndex] = payload->Message;
-                            hubClockBuffer[sampleIndex] = payload->HubClock;
+                            hubSyncCounterBuffer[sampleIndex] = payload->HubSyncCounter;
                             clockBuffer[sampleIndex] = frame.Clock;
                             if (++sampleIndex >= bufferSize)
                             {
                                 var dummy = BufferHelper.CopyBuffer(dummyBuffer, bufferSize, dummyWords, Depth.S16);
                                 var message = BufferHelper.CopyBuffer(messageBuffer, bufferSize, 1, Depth.S16);
-                                observer.OnNext(new Test0DataFrame(clockBuffer, hubClockBuffer, message, dummy));
-                                hubClockBuffer = new ulong[bufferSize];
+                                observer.OnNext(new Test0DataFrame(clockBuffer, hubSyncCounterBuffer, message, dummy));
+                                hubSyncCounterBuffer = new ulong[bufferSize];
                                 clockBuffer = new ulong[bufferSize];
                                 sampleIndex = 0;
                             }

--- a/OpenEphys.Onix/OpenEphys.Onix/Test0DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Test0DataFrame.cs
@@ -5,17 +5,17 @@ namespace OpenEphys.Onix
 {
     public class Test0DataFrame
     {
-        public Test0DataFrame(ulong[] clock, ulong[] hubClock, Mat message, Mat dummy)
+        public Test0DataFrame(ulong[] clock, ulong[] hubSyncCounter, Mat message, Mat dummy)
         {
             Clock = clock;
-            HubClock = hubClock;
+            HubSyncCounter = hubSyncCounter;
             Message = message;
             Dummy = dummy;
         }
 
         public ulong[] Clock { get; }
 
-        public ulong[] HubClock { get; }
+        public ulong[] HubSyncCounter { get; }
 
         public Mat Message { get; }
 
@@ -25,7 +25,7 @@ namespace OpenEphys.Onix
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct Test0PayloadHeader
     {
-        public ulong HubClock;
+        public ulong HubSyncCounter;
         public short Message;
     }
 }


### PR DESCRIPTION
For the majority of analysis tasks, the correct synchronized `Clock` property should be used on all frames. To avoid confusion, this PR renames all `HubClock` properties to `HubSyncCounter`.