### PR TITLE
Add helper to get fully qualified hub device name

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
@@ -21,17 +21,20 @@ namespace OpenEphys.Onix
             set
             {
                 _name = value;
-                UpdateDeviceNames(_name);
+                UpdateDeviceNames();
             }
         }
 
-        internal virtual void UpdateDeviceNames(string hubName)
+        protected string GetFullDeviceName(string deviceName)
+        {
+            return !string.IsNullOrEmpty(_name) ? $"{_name}/{deviceName}" : string.Empty;
+        }
+
+        internal virtual void UpdateDeviceNames()
         {
             foreach (var device in GetDevices())
             {
-                device.DeviceName = !string.IsNullOrEmpty(hubName)
-                    ? $"{hubName}.{device.DeviceType.Name}"
-                    : string.Empty;
+                device.DeviceName = GetFullDeviceName(device.DeviceType.Name);
             }
         }
 


### PR DESCRIPTION
On occasion it may be necessary to explicitly name devices in a hub using unique IDs other than their device type name.

To help make these explicit names more consistent, this PR introduces a new protected method `GetFullDeviceName` to the `HubDeviceFactory` class, which derived classes should use to assign full names to individually named devices.

In addition, the implementation is updated to use `/` instead of `.` to build the fully qualified device name.

Fixes #52 