### PR TITLE
AnalogIO refactoring and support for buffering and data type conversions

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
@@ -18,13 +18,13 @@ namespace OpenEphys.Onix
 
         public AnalogIODataType DataType { get; set; } = AnalogIODataType.S16;
 
-        static Mat CreateVoltageScale(int bufferSize, double[] voltsPerDivision)
+        static Mat CreateVoltageScale(int bufferSize, float[] voltsPerDivision)
         {
             using var scaleHeader = Mat.CreateMatHeader(
                 voltsPerDivision,
                 rows: voltsPerDivision.Length,
                 cols: 1,
-                depth: Depth.F64,
+                depth: Depth.F32,
                 channels: 1);
             var voltageScale = new Mat(scaleHeader.Rows, bufferSize, scaleHeader.Depth, scaleHeader.Channels);
             CV.Repeat(scaleHeader, voltageScale);
@@ -35,7 +35,7 @@ namespace OpenEphys.Onix
         {
             var bufferSize = BufferSize;
             var dataType = DataType;
-            var depth = dataType == AnalogIODataType.Volts ? Depth.F64 : Depth.S16;
+            var depth = dataType == AnalogIODataType.Volts ? Depth.F32 : Depth.S16;
             return Observable.Using(
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
@@ -61,7 +61,7 @@ namespace OpenEphys.Onix
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
-                                    var analogData = BufferHelper.CopyTransposeBuffer(
+                                    var analogData = BufferHelper.CopyBuffer(
                                         analogDataBuffer,
                                         bufferSize,
                                         AnalogIO.ChannelCount,

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
@@ -1,27 +1,57 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Runtime.InteropServices;
 using Bonsai;
+using OpenCV.Net;
 
 namespace OpenEphys.Onix
 {
-    public class AnalogInput : Source<ManagedFrame<short>>
+    public class AnalogInput : Source<AnalogInputDataFrame>
     {
         [TypeConverter(typeof(AnalogIO.NameConverter))]
         public string DeviceName { get; set; }
 
-        public override IObservable<ManagedFrame<short>> Generate()
+        public int BufferSize { get; set; } = 100;
+
+        public unsafe override IObservable<AnalogInputDataFrame> Generate()
         {
+            var bufferSize = BufferSize;
             return Observable.Using(
                 () => DeviceManager.ReserveDevice(DeviceName),
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
-                {
-                    var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
-                    return deviceInfo.Context.FrameReceived
-                        .Where(frame => frame.DeviceAddress == device.Address)
-                        .Select(frame => new ManagedFrame<short>(frame));
-                }));
+                    Observable.Create<AnalogInputDataFrame>(observer =>
+                    {
+                        var sampleIndex = 0;
+                        var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
+                        var analogDataBuffer = new short[AnalogIO.ChannelCount * bufferSize];
+                        var hubSyncCounterBuffer = new ulong[bufferSize];
+                        var clockBuffer = new ulong[bufferSize];
+
+                        var frameObserver = Observer.Create<oni.Frame>(
+                            frame =>
+                            {
+                                var payload = (AnalogInputPayload*)frame.Data.ToPointer();
+                                Marshal.Copy(new IntPtr(payload->AnalogData), analogDataBuffer, sampleIndex * AnalogIO.ChannelCount, AnalogIO.ChannelCount);
+                                hubSyncCounterBuffer[sampleIndex] = payload->HubSyncCounter;
+                                clockBuffer[sampleIndex] = frame.Clock;
+                                if (++sampleIndex >= bufferSize)
+                                {
+                                    var analogData = BufferHelper.CopyBuffer(analogDataBuffer, bufferSize, AnalogIO.ChannelCount, Depth.S16);
+                                    observer.OnNext(new AnalogInputDataFrame(clockBuffer, hubSyncCounterBuffer, analogData));
+                                    hubSyncCounterBuffer = new ulong[bufferSize];
+                                    clockBuffer = new ulong[bufferSize];
+                                    sampleIndex = 0;
+                                }
+                            },
+                            observer.OnError,
+                            observer.OnCompleted);
+                        return deviceInfo.Context.FrameReceived
+                            .Where(frame => frame.DeviceAddress == device.Address)
+                            .SubscribeSafe(frameObserver);
+                    })));
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
@@ -61,7 +61,7 @@ namespace OpenEphys.Onix
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
-                                    var analogData = BufferHelper.CopyConvertBuffer(
+                                    var analogData = BufferHelper.CopyTransposeBuffer(
                                         analogDataBuffer,
                                         bufferSize,
                                         AnalogIO.ChannelCount,

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogInput.cs
@@ -61,7 +61,7 @@ namespace OpenEphys.Onix
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
-                                    var analogData = BufferHelper.CopyBuffer(
+                                    var analogData = BufferHelper.CopyTranspose(
                                         analogDataBuffer,
                                         bufferSize,
                                         AnalogIO.ChannelCount,

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogInputDataFrame.cs
@@ -1,0 +1,28 @@
+﻿using System.Runtime.InteropServices;
+using OpenCV.Net;
+
+namespace OpenEphys.Onix
+{
+    public class AnalogInputDataFrame
+    {
+        public AnalogInputDataFrame(ulong[] clock, ulong[] hubSyncCounter, Mat analogData)
+        {
+            Clock = clock;
+            HubSyncCounter = hubSyncCounter;
+            AnalogData = analogData;
+        }
+
+        public ulong[] Clock { get; }
+
+        public ulong[] HubSyncCounter { get; }
+
+        public Mat AnalogData { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct AnalogInputPayload
+    {
+        public ulong HubSyncCounter;
+        public fixed short AnalogData[AnalogIO.ChannelCount];
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
@@ -3,15 +3,82 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
 using Bonsai;
+using OpenCV.Net;
 
 namespace OpenEphys.Onix
 {
-    public class AnalogOutput : Sink<ushort[]>
+    public class AnalogOutput : Sink<Mat>
     {
         [TypeConverter(typeof(AnalogIO.NameConverter))]
         public string DeviceName { get; set; }
 
-        public override IObservable<ushort[]> Process(IObservable<ushort[]> source)
+        public AnalogIODataType DataType { get; set; } = AnalogIODataType.S16;
+
+        static Mat CreateSampleScale(int bufferSize, float[] divisionsPerVolt)
+        {
+            using var scaleHeader = Mat.CreateMatHeader(divisionsPerVolt);
+            var voltageScale = new Mat(bufferSize, scaleHeader.Cols, scaleHeader.Depth, scaleHeader.Channels);
+            CV.Repeat(scaleHeader, voltageScale);
+            return voltageScale;
+        }
+
+        public override IObservable<Mat> Process(IObservable<Mat> source)
+        {
+            var dataType = DataType;
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var bufferSize = 0;
+                    var tempBuffer = default(Mat);
+                    var sampleScale = default(Mat);
+                    var inputBuffer = default(Mat);
+                    var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
+                    var ioDeviceInfo = (AnalogIODeviceInfo)deviceInfo;
+                    var divisionsPerVolt = Array.ConvertAll(ioDeviceInfo.VoltsPerDivision, value => 1 / value);
+                    return source.Do(data =>
+                    {
+                        if (data.Rows != AnalogIO.ChannelCount)
+                        {
+                            throw new InvalidOperationException(
+                                $"The input data matrix must have exactly {AnalogIO.ChannelCount} channels."
+                            );
+                        }
+
+                        if (dataType == AnalogIODataType.S16 && data.Depth != Depth.S16 ||
+                            dataType == AnalogIODataType.Volts && data.Depth != Depth.F32)
+                        {
+                            throw new InvalidOperationException(
+                                $"Invalid input data type '{data.Depth}' for the specified analog IO configuration."
+                            );
+                        }
+
+                        if (bufferSize != data.Cols)
+                        {
+                            bufferSize = data.Cols;
+                            sampleScale = dataType == AnalogIODataType.Volts
+                                ? CreateSampleScale(bufferSize, divisionsPerVolt)
+                                : null;
+                            inputBuffer = new Mat(data.Cols, data.Rows, data.Depth, 1);
+                            tempBuffer = sampleScale != null ? new Mat(data.Cols, data.Rows, Depth.S16, 1) : null;
+                        }
+
+                        var outputBuffer = inputBuffer;
+                        CV.Transpose(data, outputBuffer);
+                        if (sampleScale != null)
+                        {
+                            CV.Mul(inputBuffer, sampleScale, inputBuffer);
+                            CV.Convert(inputBuffer, tempBuffer);
+                            outputBuffer = tempBuffer;
+                        }
+
+                        var dataSize = inputBuffer.Step * inputBuffer.Rows;
+                        device.Write(inputBuffer.Data, dataSize);
+                    });
+                }));
+        }
+
+        public IObservable<short[]> Process(IObservable<short[]> source)
         {
             return Observable.Using(
                 () => DeviceManager.ReserveDevice(DeviceName),

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
@@ -61,7 +61,7 @@ namespace OpenEphys.Onix
                         }
 
                         var outputBuffer = inputBuffer;
-                        CV.Transpose(data, outputBuffer);
+                        CV.Transpose(data, inputBuffer);
                         if (sampleScale != null)
                         {
                             CV.Mul(inputBuffer, sampleScale, inputBuffer);
@@ -69,8 +69,8 @@ namespace OpenEphys.Onix
                             outputBuffer = tempBuffer;
                         }
 
-                        var dataSize = inputBuffer.Step * inputBuffer.Rows;
-                        device.Write(inputBuffer.Data, dataSize);
+                        var dataSize = outputBuffer.Step * outputBuffer.Rows;
+                        device.Write(outputBuffer.Data, dataSize);
                     });
                 }));
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/AnalogOutput.cs
@@ -56,17 +56,25 @@ namespace OpenEphys.Onix
                             sampleScale = dataType == AnalogIODataType.Volts
                                 ? CreateSampleScale(bufferSize, divisionsPerVolt)
                                 : null;
-                            inputBuffer = new Mat(data.Cols, data.Rows, data.Depth, 1);
-                            tempBuffer = sampleScale != null ? new Mat(data.Cols, data.Rows, Depth.S16, 1) : null;
+                            if (bufferSize > 1 || sampleScale != null)
+                            {
+                                inputBuffer = new Mat(data.Cols, data.Rows, data.Depth, 1);
+                                tempBuffer = sampleScale != null ? new Mat(data.Cols, data.Rows, Depth.S16, 1) : null;
+                            }
+                            else inputBuffer = tempBuffer = null;
                         }
 
                         var outputBuffer = inputBuffer;
-                        CV.Transpose(data, inputBuffer);
-                        if (sampleScale != null)
+                        if (inputBuffer == null) outputBuffer = data;
+                        else
                         {
-                            CV.Mul(inputBuffer, sampleScale, inputBuffer);
-                            CV.Convert(inputBuffer, tempBuffer);
-                            outputBuffer = tempBuffer;
+                            CV.Transpose(data, inputBuffer);
+                            if (sampleScale != null)
+                            {
+                                CV.Mul(inputBuffer, sampleScale, inputBuffer);
+                                CV.Convert(inputBuffer, tempBuffer);
+                                outputBuffer = tempBuffer;
+                            }
                         }
 
                         var dataSize = outputBuffer.Step * outputBuffer.Rows;

--- a/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
@@ -8,8 +8,7 @@ namespace OpenEphys.Onix
             TBuffer[] buffer,
             int sampleCount,
             int channelCount,
-            Depth depth,
-            Mat scale = null)
+            Depth depth)
             where TBuffer : unmanaged
         {
             using var bufferHeader = Mat.CreateMatHeader(
@@ -18,12 +17,34 @@ namespace OpenEphys.Onix
                 channelCount,
                 depth,
                 channels: 1);
-            var data = new Mat(bufferHeader.Cols, bufferHeader.Rows, bufferHeader.Depth, 1);
+            var data = new Mat(bufferHeader.Cols, bufferHeader.Rows, depth, 1);
             CV.Transpose(bufferHeader, data);
-            if (scale != null)
+            return data;
+        }
+
+        public static Mat CopyTranspose<TBuffer>(
+            TBuffer[] buffer,
+            int sampleCount,
+            int channelCount,
+            Depth depth,
+            Mat scale,
+            Mat transposeBuffer)
+            where TBuffer : unmanaged
+        {
+            if (scale == null)
             {
-                CV.Mul(data, scale, data);
+                return CopyTranspose(buffer, sampleCount, channelCount, depth);
             }
+
+            using var bufferHeader = Mat.CreateMatHeader(
+                buffer,
+                sampleCount,
+                channelCount,
+                depth,
+                channels: 1);
+            var data = new Mat(bufferHeader.Cols, bufferHeader.Rows, scale.Depth, 1);
+            CV.Transpose(bufferHeader, transposeBuffer);
+            CV.Mul(transposeBuffer, scale, data);
             return data;
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
@@ -4,7 +4,7 @@ namespace OpenEphys.Onix
 {
     static class BufferHelper
     {
-        public static Mat CopyBuffer<TBuffer>(
+        public static Mat CopyTranspose<TBuffer>(
             TBuffer[] buffer,
             int sampleCount,
             int channelCount,

--- a/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
@@ -41,5 +41,21 @@ namespace OpenEphys.Onix
             CV.ConvertScale(bufferHeader, data, scale, shift);
             return data;
         }
+
+        public static Mat CopyConvertBuffer<TBuffer>(
+            TBuffer[] buffer,
+            int sampleCount,
+            int channelCount,
+            Depth depth,
+            Mat scale)
+            where TBuffer : unmanaged
+        {
+            var data = CopyConvertBuffer(buffer, sampleCount, channelCount, depth);
+            if (scale != null)
+            {
+                CV.Mul(data, scale, data);
+            }
+            return data;
+        }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
@@ -21,5 +21,25 @@ namespace OpenEphys.Onix
             CV.Transpose(bufferHeader, amplifierData);
             return amplifierData;
         }
+
+        public static Mat CopyConvertBuffer<TBuffer>(
+            TBuffer[] buffer,
+            int sampleCount,
+            int channelCount,
+            Depth depth,
+            double scale = 1,
+            double shift = 0)
+            where TBuffer : unmanaged
+        {
+            using var bufferHeader = Mat.CreateMatHeader(
+                buffer,
+                channelCount,
+                sampleCount,
+                depth,
+                channels: 1);
+            var data = new Mat(bufferHeader.Rows, bufferHeader.Cols, bufferHeader.Depth, 1);
+            CV.ConvertScale(bufferHeader, data, scale, shift);
+            return data;
+        }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
@@ -42,7 +42,7 @@ namespace OpenEphys.Onix
             return data;
         }
 
-        public static Mat CopyConvertBuffer<TBuffer>(
+        public static Mat CopyTransposeBuffer<TBuffer>(
             TBuffer[] buffer,
             int sampleCount,
             int channelCount,
@@ -50,7 +50,14 @@ namespace OpenEphys.Onix
             Mat scale)
             where TBuffer : unmanaged
         {
-            var data = CopyConvertBuffer(buffer, sampleCount, channelCount, depth);
+            using var bufferHeader = Mat.CreateMatHeader(
+                buffer,
+                sampleCount,
+                channelCount,
+                depth,
+                channels: 1);
+            var data = new Mat(bufferHeader.Cols, bufferHeader.Rows, bufferHeader.Depth, 1);
+            CV.Transpose(bufferHeader, data);
             if (scale != null)
             {
                 CV.Mul(data, scale, data);

--- a/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BufferHelper.cs
@@ -8,46 +8,8 @@ namespace OpenEphys.Onix
             TBuffer[] buffer,
             int sampleCount,
             int channelCount,
-            Depth depth)
-            where TBuffer : unmanaged
-        {
-            using var bufferHeader = Mat.CreateMatHeader(
-                buffer,
-                sampleCount,
-                channelCount,
-                depth,
-                channels: 1);
-            var amplifierData = new Mat(bufferHeader.Cols, bufferHeader.Rows, bufferHeader.Depth, 1);
-            CV.Transpose(bufferHeader, amplifierData);
-            return amplifierData;
-        }
-
-        public static Mat CopyConvertBuffer<TBuffer>(
-            TBuffer[] buffer,
-            int sampleCount,
-            int channelCount,
             Depth depth,
-            double scale = 1,
-            double shift = 0)
-            where TBuffer : unmanaged
-        {
-            using var bufferHeader = Mat.CreateMatHeader(
-                buffer,
-                channelCount,
-                sampleCount,
-                depth,
-                channels: 1);
-            var data = new Mat(bufferHeader.Rows, bufferHeader.Cols, bufferHeader.Depth, 1);
-            CV.ConvertScale(bufferHeader, data, scale, shift);
-            return data;
-        }
-
-        public static Mat CopyTransposeBuffer<TBuffer>(
-            TBuffer[] buffer,
-            int sampleCount,
-            int channelCount,
-            Depth depth,
-            Mat scale)
+            Mat scale = null)
             where TBuffer : unmanaged
         {
             using var bufferHeader = Mat.CreateMatHeader(

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -230,7 +230,7 @@ namespace OpenEphys.Onix
             };
         }
 
-        static float GetVoltsPerDivision(AnalogIOVoltageRange voltageRange)
+        public static float GetVoltsPerDivision(AnalogIOVoltageRange voltageRange)
         {
             return voltageRange switch
             {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -1,25 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Reactive.Disposables;
-using System.Reactive.Subjects;
 
 namespace OpenEphys.Onix
 {
     public class ConfigureAnalogIO : SingleDeviceFactory
     {
-        readonly BehaviorSubject<ChannelDirection> direction00 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction01 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction02 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction03 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction04 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction05 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction06 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction07 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction08 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction09 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction10 = new(ChannelDirection.Input);
-        readonly BehaviorSubject<ChannelDirection> direction11 = new(ChannelDirection.Input);
-
         public ConfigureAnalogIO()
             : base(typeof(AnalogIO))
         {
@@ -80,99 +65,51 @@ namespace OpenEphys.Onix
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 0.")]
-        public ChannelDirection Direction00
-        {
-            get => direction00.Value;
-            set => direction00.OnNext(value);
-        }
+        public ChannelDirection Direction00 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 1.")]
-        public ChannelDirection Direction01
-        {
-            get => direction01.Value;
-            set => direction01.OnNext(value);
-        }
+        public ChannelDirection Direction01 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 2.")]
-        public ChannelDirection Direction02
-        {
-            get => direction02.Value;
-            set => direction02.OnNext(value);
-        }
+        public ChannelDirection Direction02 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 3.")]
-        public ChannelDirection Direction03
-        {
-            get => direction03.Value;
-            set => direction03.OnNext(value);
-        }
+        public ChannelDirection Direction03 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 4.")]
-        public ChannelDirection Direction04
-        {
-            get => direction04.Value;
-            set => direction04.OnNext(value);
-        }
+        public ChannelDirection Direction04 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 5.")]
-        public ChannelDirection Direction05
-        {
-            get => direction05.Value;
-            set => direction05.OnNext(value);
-        }
+        public ChannelDirection Direction05 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 6.")]
-        public ChannelDirection Direction06
-        {
-            get => direction06.Value;
-            set => direction06.OnNext(value);
-        }
+        public ChannelDirection Direction06 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 7.")]
-        public ChannelDirection Direction07
-        {
-            get => direction07.Value;
-            set => direction07.OnNext(value);
-        }
+        public ChannelDirection Direction07 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 8.")]
-        public ChannelDirection Direction08
-        {
-            get => direction08.Value;
-            set => direction08.OnNext(value);
-        }
+        public ChannelDirection Direction08 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 9.")]
-        public ChannelDirection Direction09
-        {
-            get => direction09.Value;
-            set => direction09.OnNext(value);
-        }
+        public ChannelDirection Direction09 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 10.")]
-        public ChannelDirection Direction10
-        {
-            get => direction10.Value;
-            set => direction10.OnNext(value);
-        }
+        public ChannelDirection Direction10 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 11.")]
-        public ChannelDirection Direction11
-        {
-            get => direction11.Value;
-            set => direction11.OnNext(value);
-        }
+        public ChannelDirection Direction11 { get; set; }
 
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
@@ -202,21 +139,19 @@ namespace OpenEphys.Onix
                     device.WriteRegister(AnalogIO.CHDIR, io_reg);
                 }
 
-                return new CompositeDisposable(
-                    DeviceManager.RegisterDevice(deviceName, device, DeviceType),
-                    direction00.Subscribe(newValue => SetIO(0, newValue)),
-                    direction01.Subscribe(newValue => SetIO(1, newValue)),
-                    direction02.Subscribe(newValue => SetIO(2, newValue)),
-                    direction03.Subscribe(newValue => SetIO(3, newValue)),
-                    direction04.Subscribe(newValue => SetIO(4, newValue)),
-                    direction05.Subscribe(newValue => SetIO(5, newValue)),
-                    direction06.Subscribe(newValue => SetIO(6, newValue)),
-                    direction07.Subscribe(newValue => SetIO(7, newValue)),
-                    direction08.Subscribe(newValue => SetIO(8, newValue)),
-                    direction09.Subscribe(newValue => SetIO(9, newValue)),
-                    direction10.Subscribe(newValue => SetIO(10, newValue)),
-                    direction11.Subscribe(newValue => SetIO(11, newValue))
-                );
+                SetIO(0, Direction00);
+                SetIO(1, Direction01);
+                SetIO(2, Direction02);
+                SetIO(3, Direction03);
+                SetIO(4, Direction04);
+                SetIO(5, Direction05);
+                SetIO(6, Direction06);
+                SetIO(7, Direction07);
+                SetIO(8, Direction08);
+                SetIO(9, Direction09);
+                SetIO(10, Direction10);
+                SetIO(11, Direction11);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 
 namespace OpenEphys.Onix
 {
+    [TypeConverter(typeof(SortedPropertyConverter))]
     public class ConfigureAnalogIO : SingleDeviceFactory
     {
         public ConfigureAnalogIO()
@@ -17,43 +19,43 @@ namespace OpenEphys.Onix
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 0.")]
-        public AnalogIOVoltageRange InputRange00 { get; set; }
+        public AnalogIOVoltageRange InputRange0 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 1.")]
-        public AnalogIOVoltageRange InputRange01 { get; set; }
+        public AnalogIOVoltageRange InputRange1 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 2.")]
-        public AnalogIOVoltageRange InputRange02 { get; set; }
+        public AnalogIOVoltageRange InputRange2 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 3.")]
-        public AnalogIOVoltageRange InputRange03 { get; set; }
+        public AnalogIOVoltageRange InputRange3 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 4.")]
-        public AnalogIOVoltageRange InputRange04 { get; set; }
+        public AnalogIOVoltageRange InputRange4 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 5.")]
-        public AnalogIOVoltageRange InputRange05 { get; set; }
+        public AnalogIOVoltageRange InputRange5 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 6.")]
-        public AnalogIOVoltageRange InputRange06 { get; set; }
+        public AnalogIOVoltageRange InputRange6 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 7.")]
-        public AnalogIOVoltageRange InputRange07 { get; set; }
+        public AnalogIOVoltageRange InputRange7 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 8.")]
-        public AnalogIOVoltageRange InputRange08 { get; set; }
+        public AnalogIOVoltageRange InputRange8 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 9.")]
-        public AnalogIOVoltageRange InputRange09 { get; set; }
+        public AnalogIOVoltageRange InputRange9 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 10.")]
@@ -65,43 +67,43 @@ namespace OpenEphys.Onix
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 0.")]
-        public AnalogIODirection Direction00 { get; set; }
+        public AnalogIODirection Direction0 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 1.")]
-        public AnalogIODirection Direction01 { get; set; }
+        public AnalogIODirection Direction1 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 2.")]
-        public AnalogIODirection Direction02 { get; set; }
+        public AnalogIODirection Direction2 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 3.")]
-        public AnalogIODirection Direction03 { get; set; }
+        public AnalogIODirection Direction3 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 4.")]
-        public AnalogIODirection Direction04 { get; set; }
+        public AnalogIODirection Direction4 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 5.")]
-        public AnalogIODirection Direction05 { get; set; }
+        public AnalogIODirection Direction5 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 6.")]
-        public AnalogIODirection Direction06 { get; set; }
+        public AnalogIODirection Direction6 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 7.")]
-        public AnalogIODirection Direction07 { get; set; }
+        public AnalogIODirection Direction7 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 8.")]
-        public AnalogIODirection Direction08 { get; set; }
+        public AnalogIODirection Direction8 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 9.")]
-        public AnalogIODirection Direction09 { get; set; }
+        public AnalogIODirection Direction9 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 10.")]
@@ -119,16 +121,16 @@ namespace OpenEphys.Onix
             {
                 var device = context.GetDeviceContext(deviceAddress, AnalogIO.ID);
                 device.WriteRegister(AnalogIO.ENABLE, Enable ? 1u : 0u);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange00);
-                device.WriteRegister(AnalogIO.CH01INRANGE, (uint)InputRange01);
-                device.WriteRegister(AnalogIO.CH02INRANGE, (uint)InputRange02);
-                device.WriteRegister(AnalogIO.CH03INRANGE, (uint)InputRange03);
-                device.WriteRegister(AnalogIO.CH04INRANGE, (uint)InputRange04);
-                device.WriteRegister(AnalogIO.CH05INRANGE, (uint)InputRange05);
-                device.WriteRegister(AnalogIO.CH06INRANGE, (uint)InputRange06);
-                device.WriteRegister(AnalogIO.CH07INRANGE, (uint)InputRange07);
-                device.WriteRegister(AnalogIO.CH08INRANGE, (uint)InputRange08);
-                device.WriteRegister(AnalogIO.CH09INRANGE, (uint)InputRange09);
+                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange0);
+                device.WriteRegister(AnalogIO.CH01INRANGE, (uint)InputRange1);
+                device.WriteRegister(AnalogIO.CH02INRANGE, (uint)InputRange2);
+                device.WriteRegister(AnalogIO.CH03INRANGE, (uint)InputRange3);
+                device.WriteRegister(AnalogIO.CH04INRANGE, (uint)InputRange4);
+                device.WriteRegister(AnalogIO.CH05INRANGE, (uint)InputRange5);
+                device.WriteRegister(AnalogIO.CH06INRANGE, (uint)InputRange6);
+                device.WriteRegister(AnalogIO.CH07INRANGE, (uint)InputRange7);
+                device.WriteRegister(AnalogIO.CH08INRANGE, (uint)InputRange8);
+                device.WriteRegister(AnalogIO.CH09INRANGE, (uint)InputRange9);
                 device.WriteRegister(AnalogIO.CH10INRANGE, (uint)InputRange10);
                 device.WriteRegister(AnalogIO.CH11INRANGE, (uint)InputRange11);
 
@@ -137,16 +139,16 @@ namespace OpenEphys.Onix
                     (io_reg & ~((uint)1 << channel)) | ((uint)(direction) << channel);
 
                 var io_reg = 0u;
-                io_reg = SetIO(io_reg, 0, Direction00);
-                io_reg = SetIO(io_reg, 1, Direction01);
-                io_reg = SetIO(io_reg, 2, Direction02);
-                io_reg = SetIO(io_reg, 3, Direction03);
-                io_reg = SetIO(io_reg, 4, Direction04);
-                io_reg = SetIO(io_reg, 5, Direction05);
-                io_reg = SetIO(io_reg, 6, Direction06);
-                io_reg = SetIO(io_reg, 7, Direction07);
-                io_reg = SetIO(io_reg, 8, Direction08);
-                io_reg = SetIO(io_reg, 9, Direction09);
+                io_reg = SetIO(io_reg, 0, Direction0);
+                io_reg = SetIO(io_reg, 1, Direction1);
+                io_reg = SetIO(io_reg, 2, Direction2);
+                io_reg = SetIO(io_reg, 3, Direction3);
+                io_reg = SetIO(io_reg, 4, Direction4);
+                io_reg = SetIO(io_reg, 5, Direction5);
+                io_reg = SetIO(io_reg, 6, Direction6);
+                io_reg = SetIO(io_reg, 7, Direction7);
+                io_reg = SetIO(io_reg, 8, Direction8);
+                io_reg = SetIO(io_reg, 9, Direction9);
                 io_reg = SetIO(io_reg, 10, Direction10);
                 io_reg = SetIO(io_reg, 11, Direction11);
                 device.WriteRegister(AnalogIO.CHDIR, io_reg);
@@ -154,6 +156,22 @@ namespace OpenEphys.Onix
                 var deviceInfo = new AnalogIODeviceInfo(device, this);
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
+        }
+
+        class SortedPropertyConverter : ExpandableObjectConverter
+        {
+            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+            {
+                var properties = base.GetProperties(context, value, attributes);
+                var sortedOrder = properties.Cast<PropertyDescriptor>()
+                                            .Where(p => p.PropertyType == typeof(AnalogIOVoltageRange)
+                                                     || p.PropertyType == typeof(AnalogIODirection))
+                                            .OrderBy(p => p.PropertyType.MetadataToken)
+                                            .Select(p => p.Name)
+                                            .Prepend(nameof(Enable))
+                                            .ToArray();
+                return properties.Sort(sortedOrder);
+            }
         }
     }
 
@@ -197,16 +215,16 @@ namespace OpenEphys.Onix
         {
             VoltsPerDivision = new[]
             {
-                GetVoltsPerDivision(deviceFactory.InputRange00),
-                GetVoltsPerDivision(deviceFactory.InputRange01),
-                GetVoltsPerDivision(deviceFactory.InputRange02),
-                GetVoltsPerDivision(deviceFactory.InputRange03),
-                GetVoltsPerDivision(deviceFactory.InputRange04),
-                GetVoltsPerDivision(deviceFactory.InputRange05),
-                GetVoltsPerDivision(deviceFactory.InputRange06),
-                GetVoltsPerDivision(deviceFactory.InputRange07),
-                GetVoltsPerDivision(deviceFactory.InputRange08),
-                GetVoltsPerDivision(deviceFactory.InputRange09),
+                GetVoltsPerDivision(deviceFactory.InputRange0),
+                GetVoltsPerDivision(deviceFactory.InputRange1),
+                GetVoltsPerDivision(deviceFactory.InputRange2),
+                GetVoltsPerDivision(deviceFactory.InputRange3),
+                GetVoltsPerDivision(deviceFactory.InputRange4),
+                GetVoltsPerDivision(deviceFactory.InputRange5),
+                GetVoltsPerDivision(deviceFactory.InputRange6),
+                GetVoltsPerDivision(deviceFactory.InputRange7),
+                GetVoltsPerDivision(deviceFactory.InputRange8),
+                GetVoltsPerDivision(deviceFactory.InputRange9),
                 GetVoltsPerDivision(deviceFactory.InputRange10),
                 GetVoltsPerDivision(deviceFactory.InputRange11)
             };

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -162,6 +162,7 @@ namespace OpenEphys.Onix
 
         // constants
         public const int ChannelCount = 12;
+        public const double VoltsPerDivision = 0.00030517578125;
 
         // managed registers
         public const uint ENABLE = 0;
@@ -202,5 +203,11 @@ namespace OpenEphys.Onix
     {
         Input = 0,
         Output = 1
+    }
+
+    public enum AnalogIODataType
+    {
+        S16,
+        Volts
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -183,17 +183,17 @@ namespace OpenEphys.Onix
                 var device = context.GetDeviceContext(deviceAddress, AnalogIO.ID);
                 device.WriteRegister(AnalogIO.ENABLE, Enable ? 1u : 0u);
                 device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange00);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange01);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange02);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange03);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange04);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange05);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange06);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange07);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange08);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange09);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange10);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange11);
+                device.WriteRegister(AnalogIO.CH01INRANGE, (uint)InputRange01);
+                device.WriteRegister(AnalogIO.CH02INRANGE, (uint)InputRange02);
+                device.WriteRegister(AnalogIO.CH03INRANGE, (uint)InputRange03);
+                device.WriteRegister(AnalogIO.CH04INRANGE, (uint)InputRange04);
+                device.WriteRegister(AnalogIO.CH05INRANGE, (uint)InputRange05);
+                device.WriteRegister(AnalogIO.CH06INRANGE, (uint)InputRange06);
+                device.WriteRegister(AnalogIO.CH07INRANGE, (uint)InputRange07);
+                device.WriteRegister(AnalogIO.CH08INRANGE, (uint)InputRange08);
+                device.WriteRegister(AnalogIO.CH09INRANGE, (uint)InputRange09);
+                device.WriteRegister(AnalogIO.CH10INRANGE, (uint)InputRange10);
+                device.WriteRegister(AnalogIO.CH11INRANGE, (uint)InputRange11);
 
                 var io_reg = 0u;
                 void SetIO(int channel, ChannelDirection direction)

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -17,99 +17,99 @@ namespace OpenEphys.Onix
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 0.")]
-        public VoltageRange InputRange00 { get; set; }
+        public AnalogIOVoltageRange InputRange00 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 1.")]
-        public VoltageRange InputRange01 { get; set; }
+        public AnalogIOVoltageRange InputRange01 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 2.")]
-        public VoltageRange InputRange02 { get; set; }
+        public AnalogIOVoltageRange InputRange02 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 3.")]
-        public VoltageRange InputRange03 { get; set; }
+        public AnalogIOVoltageRange InputRange03 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 4.")]
-        public VoltageRange InputRange04 { get; set; }
+        public AnalogIOVoltageRange InputRange04 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 5.")]
-        public VoltageRange InputRange05 { get; set; }
+        public AnalogIOVoltageRange InputRange05 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 6.")]
-        public VoltageRange InputRange06 { get; set; }
+        public AnalogIOVoltageRange InputRange06 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 7.")]
-        public VoltageRange InputRange07 { get; set; }
+        public AnalogIOVoltageRange InputRange07 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 8.")]
-        public VoltageRange InputRange08 { get; set; }
+        public AnalogIOVoltageRange InputRange08 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 9.")]
-        public VoltageRange InputRange09 { get; set; }
+        public AnalogIOVoltageRange InputRange09 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 10.")]
-        public VoltageRange InputRange10 { get; set; }
+        public AnalogIOVoltageRange InputRange10 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 11.")]
-        public VoltageRange InputRange11 { get; set; }
+        public AnalogIOVoltageRange InputRange11 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 0.")]
-        public ChannelDirection Direction00 { get; set; }
+        public AnalogIODirection Direction00 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 1.")]
-        public ChannelDirection Direction01 { get; set; }
+        public AnalogIODirection Direction01 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 2.")]
-        public ChannelDirection Direction02 { get; set; }
+        public AnalogIODirection Direction02 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 3.")]
-        public ChannelDirection Direction03 { get; set; }
+        public AnalogIODirection Direction03 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 4.")]
-        public ChannelDirection Direction04 { get; set; }
+        public AnalogIODirection Direction04 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 5.")]
-        public ChannelDirection Direction05 { get; set; }
+        public AnalogIODirection Direction05 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 6.")]
-        public ChannelDirection Direction06 { get; set; }
+        public AnalogIODirection Direction06 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 7.")]
-        public ChannelDirection Direction07 { get; set; }
+        public AnalogIODirection Direction07 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 8.")]
-        public ChannelDirection Direction08 { get; set; }
+        public AnalogIODirection Direction08 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 9.")]
-        public ChannelDirection Direction09 { get; set; }
+        public AnalogIODirection Direction09 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 10.")]
-        public ChannelDirection Direction10 { get; set; }
+        public AnalogIODirection Direction10 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 11.")]
-        public ChannelDirection Direction11 { get; set; }
+        public AnalogIODirection Direction11 { get; set; }
 
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
@@ -133,7 +133,7 @@ namespace OpenEphys.Onix
                 device.WriteRegister(AnalogIO.CH11INRANGE, (uint)InputRange11);
 
                 var io_reg = 0u;
-                void SetIO(int channel, ChannelDirection direction)
+                void SetIO(int channel, AnalogIODirection direction)
                 {
                     io_reg = (io_reg & ~((uint)1 << channel)) | ((uint)(direction) << channel);
                     device.WriteRegister(AnalogIO.CHDIR, io_reg);
@@ -160,6 +160,10 @@ namespace OpenEphys.Onix
     {
         public const int ID = 22;
 
+        // constants
+        public const int ChannelCount = 12;
+
+        // managed registers
         public const uint ENABLE = 0;
         public const uint CHDIR = 1;
         public const uint CH00INRANGE = 2;
@@ -184,7 +188,7 @@ namespace OpenEphys.Onix
         }
     }
 
-    public enum VoltageRange
+    public enum AnalogIOVoltageRange
     {
         [Description("+/-10.0 V")]
         TenVolts = 0,
@@ -194,7 +198,7 @@ namespace OpenEphys.Onix
         FiveVolts,
     }
 
-    public enum ChannelDirection
+    public enum AnalogIODirection
     {
         Input = 0,
         Output = 1

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -230,18 +230,18 @@ namespace OpenEphys.Onix
             };
         }
 
-        static double GetVoltsPerDivision(AnalogIOVoltageRange voltageRange)
+        static float GetVoltsPerDivision(AnalogIOVoltageRange voltageRange)
         {
             return voltageRange switch
             {
-                AnalogIOVoltageRange.TenVolts => 20.0 / AnalogIO.NumberOfDivisions,
-                AnalogIOVoltageRange.TwoPointFiveVolts => 5.0 / AnalogIO.NumberOfDivisions,
-                AnalogIOVoltageRange.FiveVolts => 10.0 / AnalogIO.NumberOfDivisions,
+                AnalogIOVoltageRange.TenVolts => 20.0f / AnalogIO.NumberOfDivisions,
+                AnalogIOVoltageRange.TwoPointFiveVolts => 5.0f / AnalogIO.NumberOfDivisions,
+                AnalogIOVoltageRange.FiveVolts => 10.0f / AnalogIO.NumberOfDivisions,
                 _ => throw new ArgumentOutOfRangeException(nameof(voltageRange)),
             };
         }
 
-        public double[] VoltsPerDivision { get; }
+        public float[] VoltsPerDivision { get; }
     }
 
     public enum AnalogIOVoltageRange

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -132,25 +132,25 @@ namespace OpenEphys.Onix
                 device.WriteRegister(AnalogIO.CH10INRANGE, (uint)InputRange10);
                 device.WriteRegister(AnalogIO.CH11INRANGE, (uint)InputRange11);
 
-                var io_reg = 0u;
-                void SetIO(int channel, AnalogIODirection direction)
-                {
-                    io_reg = (io_reg & ~((uint)1 << channel)) | ((uint)(direction) << channel);
-                    device.WriteRegister(AnalogIO.CHDIR, io_reg);
-                }
+                // Build the whole value for CHDIR and write it once
+                static uint SetIO(uint io_reg, int channel, AnalogIODirection direction) =>
+                    (io_reg & ~((uint)1 << channel)) | ((uint)(direction) << channel);
 
-                SetIO(0, Direction00);
-                SetIO(1, Direction01);
-                SetIO(2, Direction02);
-                SetIO(3, Direction03);
-                SetIO(4, Direction04);
-                SetIO(5, Direction05);
-                SetIO(6, Direction06);
-                SetIO(7, Direction07);
-                SetIO(8, Direction08);
-                SetIO(9, Direction09);
-                SetIO(10, Direction10);
-                SetIO(11, Direction11);
+                var io_reg = 0u;
+                io_reg = SetIO(io_reg, 0, Direction00);
+                io_reg = SetIO(io_reg, 1, Direction01);
+                io_reg = SetIO(io_reg, 2, Direction02);
+                io_reg = SetIO(io_reg, 3, Direction03);
+                io_reg = SetIO(io_reg, 4, Direction04);
+                io_reg = SetIO(io_reg, 5, Direction05);
+                io_reg = SetIO(io_reg, 6, Direction06);
+                io_reg = SetIO(io_reg, 7, Direction07);
+                io_reg = SetIO(io_reg, 8, Direction08);
+                io_reg = SetIO(io_reg, 9, Direction09);
+                io_reg = SetIO(io_reg, 10, Direction10);
+                io_reg = SetIO(io_reg, 11, Direction11);
+                device.WriteRegister(AnalogIO.CHDIR, io_reg);
+
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceInfo.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceInfo.cs
@@ -4,6 +4,11 @@ namespace OpenEphys.Onix
 {
     internal class DeviceInfo
     {
+        public DeviceInfo(DeviceContext device, Type deviceType)
+            : this(device.Context, deviceType, device.Address)
+        {
+        }
+
         public DeviceInfo(ContextTask context, Type deviceType, uint deviceAddress)
         {
             Context = context ?? throw new ArgumentNullException(nameof(context));

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceManager.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceManager.cs
@@ -12,7 +12,7 @@ namespace OpenEphys.Onix
 
         internal static IDisposable RegisterDevice(string name, DeviceContext device, Type deviceType)
         {
-            var deviceInfo = new DeviceInfo(device.Context, deviceType, device.Address);
+            var deviceInfo = new DeviceInfo(device, deviceType);
             return RegisterDevice(name, deviceInfo);
         }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -41,8 +41,8 @@ namespace OpenEphys.Onix
                                 clockBuffer[sampleIndex] = frame.Clock;
                                 if (++sampleIndex >= bufferSize)
                                 {
-                                    var amplifierData = BufferHelper.CopyBuffer(amplifierBuffer, bufferSize, Rhd2164.AmplifierChannelCount, Depth.U16);
-                                    var auxData = BufferHelper.CopyBuffer(auxBuffer, bufferSize, Rhd2164.AuxChannelCount, Depth.U16);
+                                    var amplifierData = BufferHelper.CopyTranspose(amplifierBuffer, bufferSize, Rhd2164.AmplifierChannelCount, Depth.U16);
+                                    var auxData = BufferHelper.CopyTranspose(auxBuffer, bufferSize, Rhd2164.AuxChannelCount, Depth.U16);
                                     observer.OnNext(new Rhd2164DataFrame(clockBuffer, hubClockBuffer, amplifierData, auxData));
                                     hubClockBuffer = new ulong[bufferSize];
                                     clockBuffer = new ulong[bufferSize];

--- a/OpenEphys.Onix/OpenEphys.Onix/Test0Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Test0Data.cs
@@ -49,8 +49,8 @@ namespace OpenEphys.Onix
                             clockBuffer[sampleIndex] = frame.Clock;
                             if (++sampleIndex >= bufferSize)
                             {
-                                var dummy = BufferHelper.CopyBuffer(dummyBuffer, bufferSize, dummyWords, Depth.S16);
-                                var message = BufferHelper.CopyBuffer(messageBuffer, bufferSize, 1, Depth.S16);
+                                var dummy = BufferHelper.CopyTranspose(dummyBuffer, bufferSize, dummyWords, Depth.S16);
+                                var message = BufferHelper.CopyTranspose(messageBuffer, bufferSize, 1, Depth.S16);
                                 observer.OnNext(new Test0DataFrame(clockBuffer, hubClockBuffer, message, dummy));
                                 hubClockBuffer = new ulong[bufferSize];
                                 clockBuffer = new ulong[bufferSize];


### PR DESCRIPTION
- Adds support for buffering analog input and output data
- Adds support for optional data type conversion to/from Volts
- Introduce `AnalogInputDataFrame` and expose analog data using `Mat` types
- Fixes issue where input ranges were not being assigned to every channel
- Disallow reconfiguring IO channel direction at runtime
- Refactor all properties to remove ordering prefix

Fixes #79 