### PR TITLE
Add port voltage override to base link controller and headstages

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -50,6 +50,15 @@ namespace OpenEphys.Onix
             }
         }
 
+        [Description("If defined, it will override automated voltage discovery and apply the specified voltage" +
+                     "to the headstage. Warning: this device requires 5.5V to 6.0V for proper operation." +
+                     "Supplying higher voltages may result in damage to the headstage.")]
+        public double? PortVoltage
+        {
+            get => LinkController.PortVoltage;
+            set => LinkController.PortVoltage = value;
+        }
+
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return LinkController;

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -35,6 +35,15 @@ namespace OpenEphys.Onix
             }
         }
 
+        [Description("If defined, it will override automated voltage discovery and apply the specified voltage" +
+                     "to the headstage. Warning: this device requires 5.0V to 7.0V for proper operation." +
+                     "Supplying higher voltages may result in damage to the headstage.")]
+        public double? PortVoltage
+        {
+            get => LinkController.PortVoltage;
+            set => LinkController.PortVoltage = value;
+        }
+
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return LinkController;

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
@@ -35,6 +35,15 @@ namespace OpenEphys.Onix
             }
         }
 
+        [Description("If defined, it will override automated voltage discovery and apply the specified voltage" +
+                     "to the headstage. Warning: this device requires 5.0V to 7.0V for proper operation." +
+                     "Supplying higher voltages may result in damage to the headstage.")]
+        public double? PortVoltage
+        {
+            get => LinkController.PortVoltage;
+            set => LinkController.PortVoltage = value;
+        }
+
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return LinkController;


### PR DESCRIPTION
It may be useful to have the option for manually overriding the port voltage on the FMC link controller when configuring specific devices. This PR exposes this common functionality in the base link controller class and adds a `PortVoltage` override property to existing headstages.

Fixes #74 