### PR TITLE
Add DigitalIO device configuration and data nodes

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
@@ -12,12 +12,16 @@ namespace OpenEphys.Onix
         public ConfigureAnalogIO AnalogIO { get; set; } = new();
 
         [TypeConverter(typeof(HubDeviceConverter))]
+        public ConfigureDigitalIO DigitalIO { get; set; } = new();
+
+        [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureMemoryMonitor MemoryMonitor { get; set; } = new();
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return Heartbeat;
             yield return AnalogIO;
+            yield return DigitalIO;
             yield return MemoryMonitor; 
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace OpenEphys.Onix
+{
+    public class ConfigureDigitalIO : SingleDeviceFactory
+    {
+        public ConfigureDigitalIO()
+            : base(typeof(DigitalIO))
+        {
+            DeviceAddress = 7;
+        }
+
+        [Category(ConfigurationCategory)]
+        [Description("Specifies whether the digital IO device is enabled.")]
+        public bool Enable { get; set; } = true;
+
+        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
+        {
+            var deviceName = DeviceName;
+            var deviceAddress = DeviceAddress;
+            return source.ConfigureDevice(context =>
+            {
+                var device = context.GetDeviceContext(deviceAddress, DigitalIO.ID);
+                device.WriteRegister(DigitalIO.ENABLE, Enable ? 1u : 0);
+                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
+            });
+        }
+    }
+
+    static class DigitalIO
+    {
+        public const int ID = 18;
+
+        // managed registers
+        public const uint ENABLE = 0x0; // Enable or disable the data output stream
+
+        internal class NameConverter : DeviceNameConverter
+        {
+            public NameConverter()
+                : base(typeof(DigitalIO))
+            {
+            }
+        }
+    }
+
+    [Flags]
+    public enum PortState : byte
+    {
+        Input0 = 0x1,
+        Input1 = 0x2,
+        Input2 = 0x4,
+        Input3 = 0x8,
+        Input4 = 0x10,
+        Input5 = 0x20,
+        Input6 = 0x40,
+        Input7 = 0x80,
+    }
+
+    [Flags]
+    public enum LinkState : byte
+    {
+        PortA = 0x1,
+        PortB = 0x2,
+        PortC = 0x4,
+        PortD = 0x8
+    }
+
+    [Flags]
+    public enum ButtonState : byte
+    {
+        Button0 = 0x1,
+        Button1 = 0x2,
+        Button2 = 0x4,
+        Button3 = 0x8,
+        Button4 = 0x10,
+        Button5 = 0x20
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
@@ -45,7 +45,7 @@ namespace OpenEphys.Onix
     }
 
     [Flags]
-    public enum DigitalPortState : byte
+    public enum DigitalPortState : ushort
     {
         Pin0 = 0x1,
         Pin1 = 0x2,
@@ -58,22 +58,19 @@ namespace OpenEphys.Onix
     }
 
     [Flags]
-    public enum BreakoutLinkPowerState : byte
-    {
-        PortA = 0x1,
-        PortB = 0x2,
-        PortC = 0x4,
-        PortD = 0x8
-    }
-
-    [Flags]
-    public enum BreakoutButtonState : byte
+    public enum ButtonState : ushort
     {
         Moon = 0x1,
         Triangle = 0x2,
         X = 0x4,
         Check = 0x8,
         Circle = 0x10,
-        Square = 0x20
+        Square = 0x20,
+        Reserved0 = 0x40,
+        Reserved1 = 0x80,
+        PortDOn = 0x100,
+        PortCOn = 0x200,
+        PortBOn = 0x400,
+        PortAOn = 0x800,
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
@@ -58,7 +58,7 @@ namespace OpenEphys.Onix
     }
 
     [Flags]
-    public enum ButtonState : ushort
+    public enum BreakoutButtonState : ushort
     {
         Moon = 0x1,
         Triangle = 0x2,

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
@@ -45,20 +45,20 @@ namespace OpenEphys.Onix
     }
 
     [Flags]
-    public enum PortState : byte
+    public enum DigitalPortState : byte
     {
-        Input0 = 0x1,
-        Input1 = 0x2,
-        Input2 = 0x4,
-        Input3 = 0x8,
-        Input4 = 0x10,
-        Input5 = 0x20,
-        Input6 = 0x40,
-        Input7 = 0x80,
+        Pin0 = 0x1,
+        Pin1 = 0x2,
+        Pin2 = 0x4,
+        Pin3 = 0x8,
+        Pin4 = 0x10,
+        Pin5 = 0x20,
+        Pin6 = 0x40,
+        Pin7 = 0x80,
     }
 
     [Flags]
-    public enum LinkState : byte
+    public enum BreakoutLinkPowerState : byte
     {
         PortA = 0x1,
         PortB = 0x2,
@@ -67,13 +67,13 @@ namespace OpenEphys.Onix
     }
 
     [Flags]
-    public enum ButtonState : byte
+    public enum BreakoutButtonState : byte
     {
-        Button0 = 0x1,
-        Button1 = 0x2,
-        Button2 = 0x4,
-        Button3 = 0x8,
-        Button4 = 0x10,
-        Button5 = 0x20
+        Moon = 0x1,
+        Triangle = 0x2,
+        X = 0x4,
+        Check = 0x8,
+        Circle = 0x10,
+        Square = 0x20
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalInput.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class DigitalInput : Source<DigitalInputDataFrame>
+    {
+        [TypeConverter(typeof(DigitalIO.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public unsafe override IObservable<DigitalInputDataFrame> Generate()
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                    Observable.Create<DigitalInputDataFrame>(observer =>
+                    {
+                        var device = deviceInfo.GetDeviceContext(typeof(DigitalIO));
+                        var frameObserver = Observer.Create<oni.Frame>(
+                            frame => new DigitalInputDataFrame(frame),
+                            observer.OnError,
+                            observer.OnCompleted);
+                        return deviceInfo.Context.FrameReceived
+                            .Where(frame => frame.DeviceAddress == device.Address)
+                            .SubscribeSafe(frameObserver);
+                    })));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
@@ -19,7 +19,7 @@ namespace OpenEphys.Onix
 
         public DigitalPortState DigitalInputs { get; }
 
-        public ButtonState Buttons { get; }
+        public BreakoutButtonState Buttons { get; }
 
     }
 
@@ -28,6 +28,6 @@ namespace OpenEphys.Onix
     {
         public ulong HubClock;
         public DigitalPortState DigitalInputs;
-        public ButtonState Buttons;
+        public BreakoutButtonState Buttons;
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
@@ -10,7 +10,6 @@ namespace OpenEphys.Onix
             var payload = (DigitalInputPayload*)frame.Data.ToPointer();
             HubClock = payload->HubClock;
             DigitalInputs = payload->DigitalInputs;
-            LinkPower = payload->LinkPower;
             Buttons = payload->Buttons;
         }
 
@@ -20,18 +19,15 @@ namespace OpenEphys.Onix
 
         public DigitalPortState DigitalInputs { get; }
 
-        public BreakoutLinkPowerState LinkPower { get; }
+        public ButtonState Buttons { get; }
 
-        public BreakoutButtonState Buttons { get; }
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct DigitalInputPayload
     {
         public ulong HubClock;
-        public byte Reserved0;
         public DigitalPortState DigitalInputs;
-        public BreakoutLinkPowerState LinkPower;
-        public BreakoutButtonState Buttons;
+        public ButtonState Buttons;
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
@@ -9,8 +9,8 @@ namespace OpenEphys.Onix
             Clock = frame.Clock;
             var payload = (DigitalInputPayload*)frame.Data.ToPointer();
             HubClock = payload->HubClock;
-            Port = payload->PortInputs;
-            Links = payload->Links;
+            DigitalInputs = payload->DigitalInputs;
+            LinkPower = payload->LinkPower;
             Buttons = payload->Buttons;
         }
 
@@ -18,11 +18,11 @@ namespace OpenEphys.Onix
 
         public ulong HubClock { get; }
 
-        public PortState Port { get; }
+        public DigitalPortState DigitalInputs { get; }
 
-        public LinkState Links { get; }
+        public BreakoutLinkPowerState LinkPower { get; }
 
-        public ButtonState Buttons { get; }
+        public BreakoutButtonState Buttons { get; }
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
@@ -30,8 +30,8 @@ namespace OpenEphys.Onix
     {
         public ulong HubClock;
         public byte Reserved0;
-        public PortState PortInputs;
-        public LinkState Links;
-        public ButtonState Buttons;
+        public DigitalPortState DigitalInputs;
+        public BreakoutLinkPowerState LinkPower;
+        public BreakoutButtonState Buttons;
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalInputDataFrame.cs
@@ -1,0 +1,37 @@
+﻿using System.Runtime.InteropServices;
+
+namespace OpenEphys.Onix
+{
+    public class DigitalInputDataFrame
+    {
+        public unsafe DigitalInputDataFrame(oni.Frame frame)
+        {
+            Clock = frame.Clock;
+            var payload = (DigitalInputPayload*)frame.Data.ToPointer();
+            HubClock = payload->HubClock;
+            Port = payload->PortInputs;
+            Links = payload->Links;
+            Buttons = payload->Buttons;
+        }
+
+        public ulong Clock { get; }
+
+        public ulong HubClock { get; }
+
+        public PortState Port { get; }
+
+        public LinkState Links { get; }
+
+        public ButtonState Buttons { get; }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct DigitalInputPayload
+    {
+        public ulong HubClock;
+        public byte Reserved0;
+        public PortState PortInputs;
+        public LinkState Links;
+        public ButtonState Buttons;
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalOutput.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace OpenEphys.Onix
+{
+    public class DigitalOutput : Sink<PortState>
+    {
+        [TypeConverter(typeof(DigitalIO.NameConverter))]
+        public string DeviceName { get; set; }
+
+        public override IObservable<PortState> Process(IObservable<PortState> source)
+        {
+            return Observable.Using(
+                () => DeviceManager.ReserveDevice(DeviceName),
+                disposable => disposable.Subject.SelectMany(deviceInfo =>
+                {
+                    var device = deviceInfo.GetDeviceContext(typeof(DigitalIO));
+                    return source.Do(device.Write);
+                }));
+        }
+    }
+}

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalOutput.cs
@@ -6,12 +6,12 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class DigitalOutput : Sink<PortState>
+    public class DigitalOutput : Sink<DigitalPortState>
     {
         [TypeConverter(typeof(DigitalIO.NameConverter))]
         public string DeviceName { get; set; }
 
-        public override IObservable<PortState> Process(IObservable<PortState> source)
+        public override IObservable<DigitalPortState> Process(IObservable<DigitalPortState> source)
         {
             return Observable.Using(
                 () => DeviceManager.ReserveDevice(DeviceName),

--- a/OpenEphys.Onix/OpenEphys.Onix/DigitalOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DigitalOutput.cs
@@ -18,7 +18,7 @@ namespace OpenEphys.Onix
                 disposable => disposable.Subject.SelectMany(deviceInfo =>
                 {
                     var device = deviceInfo.GetDeviceContext(typeof(DigitalIO));
-                    return source.Do(device.Write);
+                    return source.Do(value => device.Write((uint)value));
                 }));
         }
     }


### PR DESCRIPTION
- Adds support for device configuration 
- Introduce `DigitalInputDataFrame` to breakout the device to host payload
- Add DigitalIO device to `ConfigureBreakoutBoard` hub device

Fixes #80 