### PR TITLE
Add reusable helper function to find device nodes

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceHelper.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bonsai;
+using Bonsai.Expressions;
+
+namespace OpenEphys.Onix
+{
+    internal static class DeviceHelper
+    {
+        static bool IsGroup(IWorkflowExpressionBuilder builder)
+        {
+            return builder is IncludeWorkflowBuilder || builder is GroupWorkflowBuilder;
+        }
+
+        static IEnumerable<ExpressionBuilder> SelectContextElements(ExpressionBuilderGraph source)
+        {
+            foreach (var node in source)
+            {
+                var element = ExpressionBuilder.Unwrap(node.Value);
+                yield return element;
+
+                var workflowBuilder = element as IWorkflowExpressionBuilder;
+                if (IsGroup(workflowBuilder))
+                {
+                    var workflow = workflowBuilder.Workflow;
+                    if (workflow == null) continue;
+                    foreach (var groupElement in SelectContextElements(workflow))
+                    {
+                        yield return groupElement;
+                    }
+                }
+            }
+        }
+
+        static bool GetCallContext(ExpressionBuilderGraph source, ExpressionBuilderGraph target, Stack<ExpressionBuilderGraph> context)
+        {
+            context.Push(source);
+            if (source == target)
+            {
+                return true;
+            }
+
+            foreach (var element in SelectContextElements(source))
+            {
+                var groupBuilder = element as IWorkflowExpressionBuilder;
+                if (IsGroup(groupBuilder) && groupBuilder.Workflow == target)
+                {
+                    return true;
+                }
+
+                if (element is WorkflowExpressionBuilder workflowBuilder)
+                {
+                    if (GetCallContext(workflowBuilder.Workflow, target, context))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            context.Pop();
+            return false;
+        }
+
+        public static IEnumerable<IDeviceConfiguration> FindDevices(WorkflowBuilder workflowBuilder, ExpressionBuilderGraph contextBuilderGraph, Type deviceType)
+        {
+            var callContext = new Stack<ExpressionBuilderGraph>();
+            if (GetCallContext(workflowBuilder.Workflow, contextBuilderGraph, callContext))
+            {
+                return from level in callContext
+                       from element in SelectContextElements(level)
+                       let factory = ExpressionBuilder.GetWorkflowElement(element) as DeviceFactory
+                       where factory != null
+                       from device in factory.GetDevices()
+                       where device.DeviceType == deviceType
+                       select device;
+            }
+
+            return Enumerable.Empty<IDeviceConfiguration>();
+        }
+    }
+}


### PR DESCRIPTION
On occasion it may be useful for device data node editors to access properties of the device configuration. Currently there is no explicit link between configuration and data nodes other than at runtime through the device manager.

This PR refactors and exposes the routines used internally by `DeviceNameConverter` to find matching device configuration nodes as helper methods which can in the future be used by more sophisticated data stream configuration editors.

Fixes #102 