### PR TITLE
Group frame distribution by device address

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
@@ -16,8 +16,8 @@ namespace OpenEphys.Onix
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var device = deviceInfo.GetDeviceContext(typeof(Bno055));
-                return deviceInfo.Context.FrameReceived
-                    .Where(frame => frame.DeviceAddress == device.Address)
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
                     .Select(frame => new Bno055DataFrame(frame));
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogInput.cs
@@ -76,8 +76,8 @@ namespace OpenEphys.Onix
                         },
                         observer.OnError,
                         observer.OnCompleted);
-                    return deviceInfo.Context.FrameReceived
-                        .Where(frame => frame.DeviceAddress == device.Address)
+                    return deviceInfo.Context
+                        .GetDeviceFrames(device.Address)
                         .SubscribeSafe(frameObserver);
                 }));
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInput.cs
@@ -16,8 +16,8 @@ namespace OpenEphys.Onix
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var device = deviceInfo.GetDeviceContext(typeof(BreakoutDigitalIO));
-                return deviceInfo.Context.FrameReceived
-                    .Where(frame => frame.DeviceAddress == device.Address)
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
                     .Select(frame => new BreakoutDigitalInputDataFrame(frame));
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputData.cs
@@ -16,8 +16,8 @@ namespace OpenEphys.Onix
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var device = deviceInfo.GetDeviceContext(typeof(HarpSyncInput));
-                return deviceInfo.Context.FrameReceived
-                    .Where(frame => frame.DeviceAddress == device.Address)
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
                     .Select(frame => new HarpSyncInputDataFrame(frame));
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/HeartbeatData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HeartbeatData.cs
@@ -16,8 +16,8 @@ namespace OpenEphys.Onix
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
                 var device = deviceInfo.GetDeviceContext(typeof(Heartbeat));
-                return deviceInfo.Context.FrameReceived
-                    .Where(frame => frame.DeviceAddress == device.Address)
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
                     .Select(frame => new HeartbeatDataFrame(frame));
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/MemoryMonitorData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/MemoryMonitorData.cs
@@ -18,8 +18,8 @@ namespace OpenEphys.Onix
                 var device = deviceInfo.GetDeviceContext(typeof(MemoryMonitor));
                 var totalMemory = device.ReadRegister(MemoryMonitor.TOTAL_MEM);
 
-                return deviceInfo.Context.FrameReceived
-                    .Where(frame => frame.DeviceAddress == device.Address)
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
                     .Select(frame => new MemoryMonitorDataFrame(frame, totalMemory));
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eData.cs
@@ -32,7 +32,7 @@ namespace OpenEphys.Onix
                 var info = (NeuropixelsV1eDeviceInfo)deviceInfo;
                 var device = info.GetDeviceContext(typeof(NeuropixelsV1e));
                 var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
-                var probeData = device.Context.FrameReceived.Where(frame => frame.DeviceAddress == passthrough.Address);
+                var probeData = device.Context.GetDeviceFrames(passthrough.Address);
 
                 return Observable.Create<NeuropixelsV1eDataFrame>(observer =>
                 {

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
@@ -25,9 +25,9 @@ namespace OpenEphys.Onix
                 var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
                 var device = info.GetDeviceContext(typeof(NeuropixelsV2eBeta));
                 var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
-                var probeData = device.Context.FrameReceived.Where(frame =>
-                    frame.DeviceAddress == passthrough.Address &&
-                    NeuropixelsV2eBetaDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
+                var probeData = device.Context
+                    .GetDeviceFrames(passthrough.Address)
+                    .Where(frame => NeuropixelsV2eBetaDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
 
                 var gainCorrection = ProbeIndex switch
                 {

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
@@ -25,9 +25,9 @@ namespace OpenEphys.Onix
                 var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
                 var device = info.GetDeviceContext(typeof(NeuropixelsV2e));
                 var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
-                var probeData = device.Context.FrameReceived.Where(frame =>
-                    frame.DeviceAddress == passthrough.Address &&
-                    NeuropixelsV2eDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
+                var probeData = device.Context
+                    .GetDeviceFrames(passthrough.Address)
+                    .Where(frame => NeuropixelsV2eDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);
 
                 var gainCorrection = ProbeIndex switch
                 {

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -49,8 +49,8 @@ namespace OpenEphys.Onix
                         },
                         observer.OnError,
                         observer.OnCompleted);
-                    return deviceInfo.Context.FrameReceived
-                        .Where(frame => frame.DeviceAddress == device.Address)
+                    return deviceInfo.Context
+                        .GetDeviceFrames(device.Address)
                         .SubscribeSafe(frameObserver);
                 }));
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
@@ -5,19 +5,19 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class StartAcquisition : Combinator<ContextTask, oni.Frame>
+    public class StartAcquisition : Combinator<ContextTask, IGroupedObservable<uint, oni.Frame>>
     {
         public int ReadSize { get; set; } = 2048;
 
         public int WriteSize { get; set; } = 2048;
 
-        public override IObservable<oni.Frame> Process(IObservable<ContextTask> source)
+        public override IObservable<IGroupedObservable<uint, oni.Frame>> Process(IObservable<ContextTask> source)
         {
             return source.SelectMany(context =>
             {
-                return Observable.Create<oni.Frame>((observer, cancellationToken) =>
+                return Observable.Create<IGroupedObservable<uint, oni.Frame>>((observer, cancellationToken) =>
                 {
-                    var frameSubscription = context.FrameReceived.SubscribeSafe(observer);
+                    var frameSubscription = context.GroupedFrames.SubscribeSafe(observer);
                     try
                     {
                         return context.StartAsync(ReadSize, WriteSize, cancellationToken)

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1Data.cs
@@ -17,8 +17,8 @@ namespace OpenEphys.Onix
             {
                 var device = deviceInfo.GetDeviceContext(typeof(TS4231V1));
                 var hubClockPeriod = 1e6 / device.Hub.ClockHz;
-                return deviceInfo.Context.FrameReceived
-                    .Where(frame => frame.DeviceAddress == device.Address)
+                return deviceInfo.Context
+                    .GetDeviceFrames(device.Address)
                     .Select(frame => new TS4231V1DataFrame(frame, hubClockPeriod));
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1GeometricPositionData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1GeometricPositionData.cs
@@ -37,8 +37,8 @@ namespace OpenEphys.Onix
                         observer.OnError,
                         observer.OnCompleted);
 
-                    return deviceInfo.Context.FrameReceived
-                        .Where(frame => frame.DeviceAddress == device.Address)
+                    return deviceInfo.Context
+                        .GetDeviceFrames(device.Address)
                         .SubscribeSafe(frameObserver);
                 }));
         }


### PR DESCRIPTION
Device data nodes need to filter each frame by address before parsing frame contents. Because all data nodes in a workflow are operating in parallel, this means that naively each frame will be checked once by each data node.

This PR implements a more efficient distribution strategy, whereby the context task preemptively groups the frame sequence by device address and provides the sequence of groups to data nodes. With this strategy, each data node only needs to find the group with the right address at subscription time, and can then proceed to process all frames without the need for further tests.

In other words, this moves testing address complexity from `O(n * m)` to `O(n) + O(m)`, where `n` is number of frames, and `m` is number of data nodes. Given that `n` is often in the order of a few thousands per second, this has the potential to result in significant speedups, even for a small number of data nodes.

Fixes #62 