### PR TITLE
Allow override of CheckLinkState implementation

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -21,7 +21,7 @@ namespace OpenEphys.Onix
                      "Consult the device datasheet and documentation for allowable voltage ranges.")]
         public double? PortVoltage { get; set; } = null;
 
-        protected bool CheckLinkState(DeviceContext device)
+        protected virtual bool CheckLinkState(DeviceContext device)
         {
             var linkState = device.ReadRegister(FmcLinkController.LINKSTATE);
             return (linkState & FmcLinkController.LINKSTATE_SL) != 0;


### PR DESCRIPTION
Specific FMC devices such as the UCLA Miniscope V4 and RHS2116 require specific implementation details in order to check the state of the device link successfully. This PR makes the `CheckLinkState` method `virtual` to allow for this flexibility.

Fixes #120 