### PR TITLE
Read device ID from type metadata

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureAnalogIO.cs
@@ -119,7 +119,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, AnalogIO.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(AnalogIO.ENABLE, Enable ? 1u : 0u);
                 device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange0);
                 device.WriteRegister(AnalogIO.CH01INRANGE, (uint)InputRange1);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
@@ -20,7 +20,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, Bno055.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(Bno055.ENABLE, Enable ? 1u : 0);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureDS90UB9x.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureDS90UB9x.cs
@@ -21,7 +21,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, DS90UB9x.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(DS90UB9x.ENABLE, enable ? 1u : 0);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureDigitalIO.cs
@@ -21,7 +21,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, DigitalIO.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(DigitalIO.ENABLE, Enable ? 1u : 0);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -53,7 +53,7 @@ namespace OpenEphys.Onix
             })
             .ConfigureLink(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, FmcLinkController.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 void dispose() => device.WriteRegister(FmcLinkController.PORTVOLTAGE, 0);
                 device.WriteRegister(FmcLinkController.ENABLE, 1);
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
@@ -25,7 +25,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, HarpSyncInput.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(HarpSyncInput.ENABLE, Enable ? 1u : 0);
                 device.WriteRegister(HarpSyncInput.SOURCE, (uint)Source);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64ElectricalStimulator.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64ElectricalStimulator.cs
@@ -15,7 +15,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, Headstage64ElectricalStimulator.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(Headstage64ElectricalStimulator.ENABLE, 0);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
@@ -35,7 +35,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, Heartbeat.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(Heartbeat.ENABLE, 1);
                 var subscription = beatsPerSecond.Subscribe(newValue =>
                 {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureLoadTester.cs
@@ -42,7 +42,7 @@ namespace OpenEphys.Onix
             var transmittedWords = TransmittedWords;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, LoadTester.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(LoadTester.ENABLE, 1);
 
                 var clk_hz = device.ReadRegister(LoadTester.CLK_HZ);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureMemoryMonitor.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureMemoryMonitor.cs
@@ -28,7 +28,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, MemoryMonitor.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(MemoryMonitor.ENABLE, 1);
                 device.WriteRegister(MemoryMonitor.CLK_DIV, device.ReadRegister(MemoryMonitor.CLK_HZ) / SampleFrequency);
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1e.cs
@@ -56,7 +56,7 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
-                var device = context.GetPassthroughDeviceContext(deviceAddress, DS90UB9x.ID);
+                var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
                 device.WriteRegister(DS90UB9x.ENABLE, enable ? 1u : 0);
 
                 // configure deserializer aliases and serializer power supply

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1eBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1eBno055.cs
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
-                var device = context.GetPassthroughDeviceContext(deviceAddress, DS90UB9x.ID);
+                var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
                 ConfigureDeserializer(device);
                 ConfigureBno055(device);
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
@@ -42,7 +42,7 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
-                var device = context.GetPassthroughDeviceContext(deviceAddress, DS90UB9x.ID);
+                var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
                 device.WriteRegister(DS90UB9x.ENABLE, enable ? 1u : 0);
 
                 // configure deserializer aliases and serializer power supply

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
@@ -46,7 +46,7 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
-                var device = context.GetPassthroughDeviceContext(deviceAddress, DS90UB9x.ID);
+                var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
                 device.WriteRegister(DS90UB9x.ENABLE, enable ? 1u : 0);
 
                 // configure deserializer aliases and serializer power supply

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
@@ -22,7 +22,7 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 // configure device via the DS90UB9x deserializer device
-                var device = context.GetPassthroughDeviceContext(deviceAddress, DS90UB9x.ID);
+                var device = context.GetPassthroughDeviceContext(deviceAddress, typeof(DS90UB9x));
                 ConfigureDeserializer(device);
                 ConfigureBno055(device);
                 var deviceInfo = new DeviceInfo(context, DeviceType, deviceAddress);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -39,7 +39,7 @@ namespace OpenEphys.Onix
             {
                 // config register format following RHD2164 datasheet
                 // https://intantech.com/files/Intan_RHD2000_series_datasheet.pdf
-                var device = context.GetDeviceContext(deviceAddress, Rhd2164.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
 
                 var format = device.ReadRegister(Rhd2164.FORMAT);
                 var amplifierDataFormat = AmplifierDataFormat;

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231.cs
@@ -20,7 +20,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, TS4231.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(TS4231.ENABLE, Enable ? 1u : 0);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureTest0.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureTest0.cs
@@ -42,7 +42,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             return source.ConfigureDevice(context =>
             {
-                var device = context.GetDeviceContext(deviceAddress, Test0.ID);
+                var device = context.GetDeviceContext(deviceAddress, DeviceType);
                 device.WriteRegister(Test0.ENABLE, Enable ? 1u : 0);
                 FrameRateHz = device.ReadRegister(Test0.FRAMERATE);
                 DummyCount = device.ReadRegister(Test0.NUMTESTWORDS);

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextHelper.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextHelper.cs
@@ -1,20 +1,21 @@
 ﻿using System;
+using System.Reflection;
 using oni;
 
 namespace OpenEphys.Onix
 {
     static class ContextHelper
     {
-        public static DeviceContext GetDeviceContext(this ContextTask context, uint address, int id)
+        public static DeviceContext GetDeviceContext(this ContextTask context, uint address, Type expectedType)
         {
             if (!context.DeviceTable.TryGetValue(address, out Device device))
             {
-                throw new InvalidOperationException($"The specified device '{id}:{address}' is not present in the device table.");
+                ThrowDeviceNotFoundException(expectedType, address);
             }
 
-            if (device.ID != id)
+            if (device.ID != GetDeviceID(expectedType))
             {
-                throw new InvalidOperationException($"The selected device is not a {id} device.");
+                ThrowInvalidDeviceException(expectedType, address);
             }
 
             return new DeviceContext(context, device);
@@ -25,23 +26,47 @@ namespace OpenEphys.Onix
             deviceInfo.AssertType(expectedType);
             if (!deviceInfo.Context.DeviceTable.TryGetValue(deviceInfo.DeviceAddress, out Device device))
             {
-                throw new InvalidOperationException(
-                    $"The specified device '{expectedType}:{deviceInfo.DeviceAddress}' is not present in the device table."
-                );
+                ThrowDeviceNotFoundException(expectedType, deviceInfo.DeviceAddress);
             }
 
             return new DeviceContext(deviceInfo.Context, device);
         }
 
-        public static DeviceContext GetPassthroughDeviceContext(this ContextTask context, uint address, int id)
+        public static DeviceContext GetPassthroughDeviceContext(this ContextTask context, uint address, Type expectedType)
         {
             var passthroughDeviceAddress = context.GetPassthroughDeviceAddress(address);
-            return GetDeviceContext(context, passthroughDeviceAddress, id);
+            return GetDeviceContext(context, passthroughDeviceAddress, expectedType);
         }
 
-        public static DeviceContext GetPassthroughDeviceContext(this DeviceContext device, int id)
+        public static DeviceContext GetPassthroughDeviceContext(this DeviceContext device, Type expectedType)
         {
-            return GetPassthroughDeviceContext(device.Context, device.Address, id);
+            return GetPassthroughDeviceContext(device.Context, device.Address, expectedType);
+        }
+
+        static int GetDeviceID(Type deviceType)
+        {
+            var fieldInfo = deviceType.GetField(
+                "ID",
+                BindingFlags.Static |
+                BindingFlags.Public |
+                BindingFlags.NonPublic |
+                BindingFlags.IgnoreCase);
+            if (fieldInfo == null || !fieldInfo.IsLiteral)
+            {
+                throw new ArgumentException($"The specified device type {deviceType} does not have a const ID field.", nameof(deviceType));
+            }
+
+            return (int)fieldInfo.GetRawConstantValue();
+        }
+
+        static void ThrowDeviceNotFoundException(Type expectedType, uint address)
+        {
+            throw new InvalidOperationException($"Device '{expectedType.Name}' was not found in the device table at address {address}.");
+        }
+
+        static void ThrowInvalidDeviceException(Type expectedType, uint address)
+        {
+            throw new InvalidOperationException($"Invalid device ID. The device found at address {address} is not a '{expectedType.Name}' device.");
         }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceInfo.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceInfo.cs
@@ -27,7 +27,7 @@ namespace OpenEphys.Onix
             if (DeviceType != expectedType)
             {
                 throw new InvalidOperationException(
-                    $"Expected device with register type {expectedType}. Actual type is {DeviceType}."
+                    $"Expected device of type {expectedType.Name}. Actual type is {DeviceType.Name}."
                 );
             }
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eBno055Data.cs
@@ -27,7 +27,7 @@ namespace OpenEphys.Onix
                     deviceInfo => Observable.Create<Bno055DataFrame>(observer =>
                     {
                         var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV1eBno055));
-                        var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                        var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
                         var i2c = new I2CRegisterContext(passthrough, NeuropixelsV1eBno055.BNO055Address);
 
                         var pollingObserver = Observer.Create<TSource>(

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eData.cs
@@ -33,7 +33,7 @@ namespace OpenEphys.Onix
                 {
                     var info = (NeuropixelsV1eDeviceInfo)deviceInfo;
                     var device = info.GetDeviceContext(typeof(NeuropixelsV1e));
-                    var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                    var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
                     var probeData = device.Context.FrameReceived.Where(frame => frame.DeviceAddress == passthrough.Address);
 
                     return Observable.Create<NeuropixelsV1eDataFrame>(observer =>

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
@@ -26,7 +26,7 @@ namespace OpenEphys.Onix
                 {
                     var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
                     var device = info.GetDeviceContext(typeof(NeuropixelsV2eBeta));
-                    var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                    var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
                     var probeData = device.Context.FrameReceived.Where(frame =>
                         frame.DeviceAddress == passthrough.Address &&
                         NeuropixelsV2eBetaDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
@@ -27,7 +27,7 @@ namespace OpenEphys.Onix
                     deviceInfo => Observable.Create<Bno055DataFrame>(observer =>
                     {
                         var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV2eBno055));
-                        var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                        var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
                         var i2c = new I2CRegisterContext(passthrough, NeuropixelsV2eBno055.BNO055Address);
 
                         var pollingObserver = Observer.Create<TSource>(

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
@@ -26,7 +26,7 @@ namespace OpenEphys.Onix
                 {
                     var info = (NeuropixelsV2eDeviceInfo)deviceInfo;
                     var device = info.GetDeviceContext(typeof(NeuropixelsV2e));
-                    var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
+                    var passthrough = device.GetPassthroughDeviceContext(typeof(DS90UB9x));
                     var probeData = device.Context.FrameReceived.Where(frame =>
                         frame.DeviceAddress == passthrough.Address &&
                         NeuropixelsV2eDataFrame.GetProbeIndex(frame) == (int)ProbeIndex);


### PR DESCRIPTION
The current implementation of `GetDeviceContext` and `GetPassthroughDeviceContext` explicitly receives the device ID as a numerical argument. While functionally sound, this approach makes it harder to generate informative error messages, since there is no way to map the ID back to a device name.

This PR refactors this approach to instead receive the expected device type. The numerical device ID is then extracted directly from the type metadata by searching for a literal field with the name `ID`. If no such field is found, or a device with an invalid ID is detected, the exception will now contain the type name.

The change also establishes parity between `ContextHelper.GetDeviceContext` and `DeviceInfo.GetDeviceContext` as they now both receive types as arguments.

The main caveat of this approach is that now declaring a static class with a `const ID` field is no longer optional. Since the approach relies on type metadata, the compiler cannot enforce the compliance of device types with this rule at compile-time. This is probably minor as any errors or inconsistencies will immediately throw errors on any test. The most significant impact will be refactoring the name of this field in the long-term, which would have to be done with care.

Fixes #116 