### PR TITLE
Ensure any BNO polling exceptions are routed

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
@@ -33,11 +33,11 @@ namespace OpenEphys.Onix
         {
             var deviceName = DeviceName;
             var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, Heartbeat.ID);
                 device.WriteRegister(Heartbeat.ENABLE, 1);
-                var subscription = beatsPerSecond.Subscribe(newValue =>
+                var subscription = beatsPerSecond.SubscribeSafe(observer, newValue =>
                 {
                     var clkHz = device.ReadRegister(Heartbeat.CLK_HZ);
                     device.WriteRegister(Heartbeat.CLK_DIV, clkHz / newValue);

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureLoadTester.cs
@@ -40,7 +40,7 @@ namespace OpenEphys.Onix
             var deviceAddress = DeviceAddress;
             var receivedWords = ReceivedWords;
             var transmittedWords = TransmittedWords;
-            return source.ConfigureDevice(context =>
+            return source.ConfigureDevice((context, observer) =>
             {
                 var device = context.GetDeviceContext(deviceAddress, LoadTester.ID);
                 device.WriteRegister(LoadTester.ENABLE, 1);
@@ -59,7 +59,7 @@ namespace OpenEphys.Onix
 
                 var writeArray = Enumerable.Repeat((uint)42, (int)(transmittedWords + 2)).ToArray();
                 device.WriteRegister(LoadTester.HTOD32_WORDS, transmittedWords);
-                var frameHzSubscription = frameHz.Subscribe(newValue =>
+                var frameHzSubscription = frameHz.SubscribeSafe(observer, newValue =>
                 {
                     device.WriteRegister(LoadTester.CLK_DIV, clk_hz / newValue);
                     var max_size = ValidSize();

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1e.cs
@@ -87,15 +87,14 @@ namespace OpenEphys.Onix
                 }
 
                 var deviceInfo = new NeuropixelsV1eDeviceInfo(context, DeviceType, deviceAddress, probeControl);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
                 var shutdown = Disposable.Create(() =>
                 {
                     serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, NeuropixelsV1e.DefaultGPO10Config);
                     serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO32, NeuropixelsV1e.DefaultGPO32Config);
                 });
                 return new CompositeDisposable(
-                    shutdown,
-                    disposable);
+                    DeviceManager.RegisterDevice(deviceName, deviceInfo),
+                    shutdown);
             });
         }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
@@ -87,15 +87,14 @@ namespace OpenEphys.Onix
                 }
 
                 var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
                 var shutdown = Disposable.Create(() =>
                 {
                     serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, NeuropixelsV2e.DefaultGPO10Config);
                     SelectProbe(serializer, NeuropixelsV2e.NoProbeSelected);
                 });
                 return new CompositeDisposable(
-                    shutdown,
-                    disposable);
+                    DeviceManager.RegisterDevice(deviceName, deviceInfo),
+                    shutdown);
             });
         }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
@@ -115,15 +115,14 @@ namespace OpenEphys.Onix
                 SyncProbes(serializer, gpo10Config);
 
                 var deviceInfo = new NeuropixelsV2eDeviceInfo(context, DeviceType, deviceAddress, gainCorrectionA, gainCorrectionB);
-                var disposable = DeviceManager.RegisterDevice(deviceName, deviceInfo);
                 var shutdown = Disposable.Create(() =>
                 {
                     serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO10, NeuropixelsV2eBeta.DefaultGPO10Config);
                     serializer.WriteByte((uint)DS90UB9xSerializerI2CRegister.GPIO32, NeuropixelsV2eBeta.DefaultGPO32Config);
                 });
                 return new CompositeDisposable(
-                    shutdown,
-                    disposable);
+                    DeviceManager.RegisterDevice(deviceName, deviceInfo),
+                    shutdown);
             });
         }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64ElectricalStimulatorTrigger.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64ElectricalStimulatorTrigger.cs
@@ -161,19 +161,19 @@ namespace OpenEphys.Onix
                         }
 
                         return new CompositeDisposable(
-                            enable.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.ENABLE, value ? 1u : 0u)),
-                            phaseOneCurrent.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT1, uAToCode(value))),
-                            interPhaseCurrent.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.RESTCURR, uAToCode(value))),
-                            phaseTwoCurrent.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT2, uAToCode(value))),
-                            trainDelay.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.TRAINDELAY, value)),
-                            phaseOneDuration.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.PULSEDUR1, value)),
-                            interPhaseInterval.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.INTERPHASEINTERVAL, value)),
-                            phaseTwoDuration.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.PULSEDUR2, value)),
-                            interPulseInterval.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.INTERPULSEINTERVAL, value)),
-                            interBurstInterval.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.INTERBURSTINTERVAL, value)),
-                            burstPulseCount.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.BURSTCOUNT, value)),
-                            trainBurstCount.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.TRAINCOUNT, value)),
-                            powerEnable.Subscribe(value => device.WriteRegister(Headstage64ElectricalStimulator.POWERON, value ? 1u : 0u)),
+                            enable.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.ENABLE, value ? 1u : 0u)),
+                            phaseOneCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT1, uAToCode(value))),
+                            interPhaseCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.RESTCURR, uAToCode(value))),
+                            phaseTwoCurrent.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.CURRENT2, uAToCode(value))),
+                            trainDelay.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.TRAINDELAY, value)),
+                            phaseOneDuration.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.PULSEDUR1, value)),
+                            interPhaseInterval.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.INTERPHASEINTERVAL, value)),
+                            phaseTwoDuration.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.PULSEDUR2, value)),
+                            interPulseInterval.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.INTERPULSEINTERVAL, value)),
+                            interBurstInterval.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.INTERBURSTINTERVAL, value)),
+                            burstPulseCount.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.BURSTCOUNT, value)),
+                            trainBurstCount.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.TRAINCOUNT, value)),
+                            powerEnable.SubscribeSafe(observer, value => device.WriteRegister(Headstage64ElectricalStimulator.POWERON, value ? 1u : 0u)),
                             source.SubscribeSafe(triggerObserver)
                         );
                     })));

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eBno055Data.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Linq;
 using Bonsai;
 
@@ -29,30 +28,25 @@ namespace OpenEphys.Onix
                         var device = deviceInfo.GetDeviceContext(typeof(NeuropixelsV1eBno055));
                         var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
                         var i2c = new I2CRegisterContext(passthrough, NeuropixelsV1eBno055.BNO055Address);
-
-                        var pollingObserver = Observer.Create<TSource>(
-                            _ =>
+                        return source.SubscribeSafe(observer, _ =>
+                        {
+                            Bno055DataFrame frame = default;
+                            device.Context.EnsureContext(() =>
                             {
-                                Bno055DataFrame frame = default;
-                                device.Context.EnsureContext(() =>
+                                var data = i2c.ReadBytes(NeuropixelsV1eBno055.DataAddress, sizeof(Bno055DataPayload));
+                                ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
+                                clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;
+                                fixed (byte* dataPtr = data)
                                 {
-                                    var data = i2c.ReadBytes(NeuropixelsV1eBno055.DataAddress, sizeof(Bno055DataPayload));
-                                    ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
-                                    clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;
-                                    fixed (byte* dataPtr = data)
-                                    {
-                                        frame = new Bno055DataFrame(clock, (Bno055DataPayload*)dataPtr);
-                                    }
-                                });
-
-                                if (frame != null)
-                                {
-                                    observer.OnNext(frame);
+                                    frame = new Bno055DataFrame(clock, (Bno055DataPayload*)dataPtr);
                                 }
-                            },
-                            observer.OnError,
-                            observer.OnCompleted);
-                        return source.SubscribeSafe(pollingObserver);
+                            });
+
+                            if (frame != null)
+                            {
+                                observer.OnNext(frame);
+                            }
+                        });
                     })));
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Linq;
 using Bonsai;
 
@@ -30,29 +29,25 @@ namespace OpenEphys.Onix
                         var passthrough = device.GetPassthroughDeviceContext(DS90UB9x.ID);
                         var i2c = new I2CRegisterContext(passthrough, NeuropixelsV2eBno055.BNO055Address);
 
-                        var pollingObserver = Observer.Create<TSource>(
-                            _ =>
+                        return source.SubscribeSafe(observer, _ =>
+                        {
+                            Bno055DataFrame frame = default;
+                            device.Context.EnsureContext(() =>
                             {
-                                Bno055DataFrame frame = default;
-                                device.Context.EnsureContext(() =>
+                                var data = i2c.ReadBytes(NeuropixelsV2eBno055.DataAddress, sizeof(Bno055DataPayload));
+                                ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
+                                clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;
+                                fixed (byte* dataPtr = data)
                                 {
-                                    var data = i2c.ReadBytes(NeuropixelsV2eBno055.DataAddress, sizeof(Bno055DataPayload));
-                                    ulong clock = passthrough.ReadRegister(DS90UB9x.LASTI2CL);
-                                    clock += (ulong)passthrough.ReadRegister(DS90UB9x.LASTI2CH) << 32;
-                                    fixed (byte* dataPtr = data)
-                                    {
-                                        frame = new Bno055DataFrame(clock, (Bno055DataPayload*)dataPtr);
-                                    }
-                                });
-
-                                if (frame != null)
-                                {
-                                    observer.OnNext(frame);
+                                    frame = new Bno055DataFrame(clock, (Bno055DataPayload*)dataPtr);
                                 }
-                            },
-                            observer.OnError,
-                            observer.OnCompleted);
-                        return source.SubscribeSafe(pollingObserver);
+                            });
+
+                            if (frame != null)
+                            {
+                                observer.OnNext(frame);
+                            }
+                        });
                     })));
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
@@ -79,7 +79,6 @@ namespace OpenEphys.Onix
                     catch (Exception ex)
                     {
                         observer.OnError(ex);
-                        throw;
                     }
                 },
                 observer.OnError,

--- a/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
@@ -72,6 +72,7 @@ namespace OpenEphys.Onix
                     catch (Exception ex)
                     {
                         observer.OnError(ex);
+                        throw;
                     }
                 },
                 observer.OnError,

--- a/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
@@ -59,5 +59,24 @@ namespace OpenEphys.Onix
                 return source.SubscribeSafe(contextObserver);
             });
         }
+
+        public static IDisposable SubscribeSafe<TSource, TResult>(
+            this IObservable<TSource> source,
+            IObserver<TResult> observer,
+            Action<TSource> onNext)
+        {
+            var sourceObserver = Observer.Create<TSource>(
+                value =>
+                {
+                    try { onNext(value); }
+                    catch (Exception ex)
+                    {
+                        observer.OnError(ex);
+                    }
+                },
+                observer.OnError,
+                observer.OnCompleted);
+            return source.SubscribeSafe(sourceObserver);
+        }
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ObservableExtensions.cs
@@ -22,6 +22,13 @@ namespace OpenEphys.Onix
             return source.ConfigureContext((context, action) => context.ConfigureDevice(action), configure);
         }
 
+        public static IObservable<ContextTask> ConfigureDevice(this IObservable<ContextTask> source, Func<ContextTask, IObserver<ContextTask>, IDisposable> configure)
+        {
+            return Observable.Create<ContextTask>(observer => source
+                .ConfigureDevice(context => configure(context, observer))
+                .SubscribeSafe(observer));
+        }
+
         static IObservable<ContextTask> ConfigureContext(
             this IObservable<ContextTask> source,
             Action<ContextTask, Func<ContextTask, IDisposable>> configureContext,


### PR DESCRIPTION
BNO polling was guarded against asynchronous context tear-down, but not against random register access exceptions such as may happen following arbitrary disconnects.

This PR attempts to guard against this by routing any exceptions thrown by the polling action to the downstream observer error channel. This might not have been necessary in other devices since frame distribution may be managed differently by the context task and the lower-level firmware. If this approach is successful, we could easily apply it to all cases.

We also introduce a new overload for `ConfigureDevice` which allows similar protection against any exceptions raised by dynamic configuration properties, as described in #128.

Fixes #121 
Fixes #128 