### PR TITLE
Refactor context task to allow asynchronous dispose

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
@@ -10,9 +10,9 @@ namespace OpenEphys.Onix
     [WorkflowElementCategory(ElementCategory.Source)]
     public class CreateContext
     {
-        public string Driver { get; set; } = "riffa";
+        public string Driver { get; set; } = ContextTask.DefaultDriver;
 
-        public int Index { get; set; }
+        public int Index { get; set; } = ContextTask.DefaultIndex;
 
         public IObservable<ContextTask> Generate()
         {


### PR DESCRIPTION
The current implementation of `ContextTask` is blocking with respect to both register access, start and stop of acquisition and context disposal, with a significant amount of state shared across calls.

Here we propose to refactor the implementation to eliminate almost all shared state, and instead redefine the acquisition task as a proper [TPL](https://learn.microsoft.com/en-us/dotnet/standard/parallel-programming/task-parallel-library-tpl) task composed of two sub-tasks, `readFrames`and `distributeFrames`. This task can be cancelled asynchronously and therefore allows implementing a non-blocking version of the `Dispose` method which simply triggers acquisition task cancellation and prevents its restart.

`StartAsync` method calls are also meant to be mutually exclusive, so care was taken to prevent acquisition tasks to be called concurrently on the same context.

Fixes #131 