### PR TITLE
Remove Rhd2164AmplifierDataFormat

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -15,10 +15,6 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         [Category(ConfigurationCategory)]
-        [Description("Specifies the raw ADC output format used for amplifier conversions.")]
-        public Rhd2164AmplifierDataFormat AmplifierDataFormat { get; set; }
-
-        [Category(ConfigurationCategory)]
         [Description("Specifies the cutoff frequency for the DSP high-pass filter used for amplifier offset removal.")]
         public Rhd2164DspCutoff DspCutoff { get; set; } = Rhd2164DspCutoff.Dsp146mHz;
 
@@ -42,9 +38,7 @@ namespace OpenEphys.Onix
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
 
                 var format = device.ReadRegister(Rhd2164.FORMAT);
-                var amplifierDataFormat = AmplifierDataFormat;
-                format &= ~(1u << 6);
-                format |= (uint)amplifierDataFormat << 6;
+                format &= ~(1u << 6); // hard-code amplifier data format to offset binary
 
                 var dspCutoff = DspCutoff;
                 if (dspCutoff == Rhd2164DspCutoff.Off)

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Config.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Config.cs
@@ -196,10 +196,4 @@ namespace OpenEphys.Onix
         /// </summary>
         Off
     }
-
-    public enum Rhd2164AmplifierDataFormat
-    {
-        Unsigned,
-        TwosComplement
-    }
 }


### PR DESCRIPTION
- This property affected the raw data fomat produced by the RHD2164 chip. However, when twos-complement was selected, it was not respected by the Rhd2164Data node.
- Further, the ability to select between twos-comp and offset binary is not useful. More useful would be adding the ability to represent data as uV in the Rhd2164Data node.