### PR TITLE
Rename AnalogIO and DigitalIO to refer to breakout

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogInputDataFrame.cs
@@ -3,9 +3,9 @@ using OpenCV.Net;
 
 namespace OpenEphys.Onix
 {
-    public class AnalogInputDataFrame : BufferedDataFrame
+    public class BreakoutAnalogInputDataFrame : BufferedDataFrame
     {
-        public AnalogInputDataFrame(ulong[] clock, ulong[] hubClock, Mat analogData)
+        public BreakoutAnalogInputDataFrame(ulong[] clock, ulong[] hubClock, Mat analogData)
             : base(clock, hubClock)
         {
             AnalogData = analogData;
@@ -15,9 +15,9 @@ namespace OpenEphys.Onix
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    unsafe struct AnalogInputPayload
+    unsafe struct BreakoutAnalogInputPayload
     {
         public ulong HubClock;
-        public fixed short AnalogData[AnalogIO.ChannelCount];
+        public fixed short AnalogData[BreakoutAnalogIO.ChannelCount];
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogOutput.cs
@@ -7,14 +7,14 @@ using OpenCV.Net;
 
 namespace OpenEphys.Onix
 {
-    public class AnalogOutput : Sink<Mat>
+    public class BreakoutAnalogOutput : Sink<Mat>
     {
-        const AnalogIOVoltageRange OutputRange = AnalogIOVoltageRange.TenVolts;
+        const BreakoutAnalogIOVoltageRange OutputRange = BreakoutAnalogIOVoltageRange.TenVolts;
 
-        [TypeConverter(typeof(AnalogIO.NameConverter))]
+        [TypeConverter(typeof(BreakoutAnalogIO.NameConverter))]
         public string DeviceName { get; set; }
 
-        public AnalogIODataType DataType { get; set; } = AnalogIODataType.S16;
+        public BreakoutAnalogIODataType DataType { get; set; } = BreakoutAnalogIODataType.S16;
 
         public override IObservable<Mat> Process(IObservable<Mat> source)
         {
@@ -24,14 +24,14 @@ namespace OpenEphys.Onix
                 var bufferSize = 0;
                 var scaleBuffer = default(Mat);
                 var transposeBuffer = default(Mat);
-                var sampleScale = dataType == AnalogIODataType.Volts
-                    ? 1 / AnalogIODeviceInfo.GetVoltsPerDivision(OutputRange)
+                var sampleScale = dataType == BreakoutAnalogIODataType.Volts
+                    ? 1 / BreakoutAnalogIODeviceInfo.GetVoltsPerDivision(OutputRange)
                     : 1;
-                var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
+                var device = deviceInfo.GetDeviceContext(typeof(BreakoutAnalogIO));
                 return source.Do(data =>
                 {
-                    if (dataType == AnalogIODataType.S16 && data.Depth != Depth.S16 ||
-                        dataType == AnalogIODataType.Volts && data.Depth != Depth.F32)
+                    if (dataType == BreakoutAnalogIODataType.S16 && data.Depth != Depth.S16 ||
+                        dataType == BreakoutAnalogIODataType.Volts && data.Depth != Depth.F32)
                     {
                         ThrowDataTypeException(data.Depth);
                     }
@@ -73,12 +73,12 @@ namespace OpenEphys.Onix
 
         public IObservable<short[]> Process(IObservable<short[]> source)
         {
-            if (DataType != AnalogIODataType.S16)
+            if (DataType != BreakoutAnalogIODataType.S16)
                 ThrowDataTypeException(Depth.S16);
 
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
+                var device = deviceInfo.GetDeviceContext(typeof(BreakoutAnalogIO));
                 return source.Do(data =>
                 {
                     AssertChannelCount(data.Length);
@@ -89,13 +89,13 @@ namespace OpenEphys.Onix
 
         public IObservable<float[]> Process(IObservable<float[]> source)
         {
-            if (DataType != AnalogIODataType.Volts)
+            if (DataType != BreakoutAnalogIODataType.Volts)
                 ThrowDataTypeException(Depth.F32);
 
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(AnalogIO));
-                var divisionsPerVolt = 1 / AnalogIODeviceInfo.GetVoltsPerDivision(OutputRange);
+                var device = deviceInfo.GetDeviceContext(typeof(BreakoutAnalogIO));
+                var divisionsPerVolt = 1 / BreakoutAnalogIODeviceInfo.GetVoltsPerDivision(OutputRange);
                 return source.Do(data =>
                 {
                     AssertChannelCount(data.Length);
@@ -112,10 +112,10 @@ namespace OpenEphys.Onix
 
         static void AssertChannelCount(int channels)
         {
-            if (channels != AnalogIO.ChannelCount)
+            if (channels != BreakoutAnalogIO.ChannelCount)
             {
                 throw new InvalidOperationException(
-                    $"The input data must have exactly {AnalogIO.ChannelCount} channels."
+                    $"The input data must have exactly {BreakoutAnalogIO.ChannelCount} channels."
                 );
             }
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInput.cs
@@ -6,19 +6,19 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class DigitalInput : Source<DigitalInputDataFrame>
+    public class BreakoutDigitalInput : Source<BreakoutDigitalInputDataFrame>
     {
-        [TypeConverter(typeof(DigitalIO.NameConverter))]
+        [TypeConverter(typeof(BreakoutDigitalIO.NameConverter))]
         public string DeviceName { get; set; }
 
-        public unsafe override IObservable<DigitalInputDataFrame> Generate()
+        public unsafe override IObservable<BreakoutDigitalInputDataFrame> Generate()
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(DigitalIO));
+                var device = deviceInfo.GetDeviceContext(typeof(BreakoutDigitalIO));
                 return deviceInfo.Context.FrameReceived
                     .Where(frame => frame.DeviceAddress == device.Address)
-                    .Select(frame => new DigitalInputDataFrame(frame));
+                    .Select(frame => new BreakoutDigitalInputDataFrame(frame));
             });
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInputDataFrame.cs
@@ -2,28 +2,28 @@
 
 namespace OpenEphys.Onix
 {
-    public class DigitalInputDataFrame : DataFrame
+    public class BreakoutDigitalInputDataFrame : DataFrame
     {
-        public unsafe DigitalInputDataFrame(oni.Frame frame)
+        public unsafe BreakoutDigitalInputDataFrame(oni.Frame frame)
             : base(frame.Clock)
         {
-            var payload = (DigitalInputPayload*)frame.Data.ToPointer();
+            var payload = (BreakoutDigitalInputPayload*)frame.Data.ToPointer();
             HubClock = payload->HubClock;
             DigitalInputs = payload->DigitalInputs;
             Buttons = payload->Buttons;
         }
 
-        public DigitalPortState DigitalInputs { get; }
+        public BreakoutDigitalPortState DigitalInputs { get; }
 
         public BreakoutButtonState Buttons { get; }
 
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    struct DigitalInputPayload
+    struct BreakoutDigitalInputPayload
     {
         public ulong HubClock;
-        public DigitalPortState DigitalInputs;
+        public BreakoutDigitalPortState DigitalInputs;
         public BreakoutButtonState Buttons;
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalOutput.cs
@@ -6,16 +6,16 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
-    public class DigitalOutput : Sink<DigitalPortState>
+    public class BreakoutDigitalOutput : Sink<BreakoutDigitalPortState>
     {
-        [TypeConverter(typeof(DigitalIO.NameConverter))]
+        [TypeConverter(typeof(BreakoutDigitalIO.NameConverter))]
         public string DeviceName { get; set; }
 
-        public override IObservable<DigitalPortState> Process(IObservable<DigitalPortState> source)
+        public override IObservable<BreakoutDigitalPortState> Process(IObservable<BreakoutDigitalPortState> source)
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>
             {
-                var device = deviceInfo.GetDeviceContext(typeof(DigitalIO));
+                var device = deviceInfo.GetDeviceContext(typeof(BreakoutDigitalIO));
                 return source.Do(value => device.Write((uint)value));
             });
         }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutAnalogIO.cs
@@ -5,10 +5,10 @@ using System.Linq;
 namespace OpenEphys.Onix
 {
     [TypeConverter(typeof(SortedPropertyConverter))]
-    public class ConfigureAnalogIO : SingleDeviceFactory
+    public class ConfigureBreakoutAnalogIO : SingleDeviceFactory
     {
-        public ConfigureAnalogIO()
-            : base(typeof(AnalogIO))
+        public ConfigureBreakoutAnalogIO()
+            : base(typeof(BreakoutAnalogIO))
         {
             DeviceAddress = 6;
         }
@@ -19,99 +19,99 @@ namespace OpenEphys.Onix
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 0.")]
-        public AnalogIOVoltageRange InputRange0 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange0 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 1.")]
-        public AnalogIOVoltageRange InputRange1 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange1 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 2.")]
-        public AnalogIOVoltageRange InputRange2 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange2 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 3.")]
-        public AnalogIOVoltageRange InputRange3 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange3 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 4.")]
-        public AnalogIOVoltageRange InputRange4 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange4 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 5.")]
-        public AnalogIOVoltageRange InputRange5 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange5 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 6.")]
-        public AnalogIOVoltageRange InputRange6 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange6 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 7.")]
-        public AnalogIOVoltageRange InputRange7 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange7 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 8.")]
-        public AnalogIOVoltageRange InputRange8 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange8 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 9.")]
-        public AnalogIOVoltageRange InputRange9 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange9 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 10.")]
-        public AnalogIOVoltageRange InputRange10 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange10 { get; set; }
 
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 11.")]
-        public AnalogIOVoltageRange InputRange11 { get; set; }
+        public BreakoutAnalogIOVoltageRange InputRange11 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 0.")]
-        public AnalogIODirection Direction0 { get; set; }
+        public BreakoutAnalogIODirection Direction0 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 1.")]
-        public AnalogIODirection Direction1 { get; set; }
+        public BreakoutAnalogIODirection Direction1 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 2.")]
-        public AnalogIODirection Direction2 { get; set; }
+        public BreakoutAnalogIODirection Direction2 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 3.")]
-        public AnalogIODirection Direction3 { get; set; }
+        public BreakoutAnalogIODirection Direction3 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 4.")]
-        public AnalogIODirection Direction4 { get; set; }
+        public BreakoutAnalogIODirection Direction4 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 5.")]
-        public AnalogIODirection Direction5 { get; set; }
+        public BreakoutAnalogIODirection Direction5 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 6.")]
-        public AnalogIODirection Direction6 { get; set; }
+        public BreakoutAnalogIODirection Direction6 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 7.")]
-        public AnalogIODirection Direction7 { get; set; }
+        public BreakoutAnalogIODirection Direction7 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 8.")]
-        public AnalogIODirection Direction8 { get; set; }
+        public BreakoutAnalogIODirection Direction8 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 9.")]
-        public AnalogIODirection Direction9 { get; set; }
+        public BreakoutAnalogIODirection Direction9 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 10.")]
-        public AnalogIODirection Direction10 { get; set; }
+        public BreakoutAnalogIODirection Direction10 { get; set; }
 
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 11.")]
-        public AnalogIODirection Direction11 { get; set; }
+        public BreakoutAnalogIODirection Direction11 { get; set; }
 
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
@@ -120,22 +120,22 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
-                device.WriteRegister(AnalogIO.ENABLE, Enable ? 1u : 0u);
-                device.WriteRegister(AnalogIO.CH00INRANGE, (uint)InputRange0);
-                device.WriteRegister(AnalogIO.CH01INRANGE, (uint)InputRange1);
-                device.WriteRegister(AnalogIO.CH02INRANGE, (uint)InputRange2);
-                device.WriteRegister(AnalogIO.CH03INRANGE, (uint)InputRange3);
-                device.WriteRegister(AnalogIO.CH04INRANGE, (uint)InputRange4);
-                device.WriteRegister(AnalogIO.CH05INRANGE, (uint)InputRange5);
-                device.WriteRegister(AnalogIO.CH06INRANGE, (uint)InputRange6);
-                device.WriteRegister(AnalogIO.CH07INRANGE, (uint)InputRange7);
-                device.WriteRegister(AnalogIO.CH08INRANGE, (uint)InputRange8);
-                device.WriteRegister(AnalogIO.CH09INRANGE, (uint)InputRange9);
-                device.WriteRegister(AnalogIO.CH10INRANGE, (uint)InputRange10);
-                device.WriteRegister(AnalogIO.CH11INRANGE, (uint)InputRange11);
+                device.WriteRegister(BreakoutAnalogIO.ENABLE, Enable ? 1u : 0u);
+                device.WriteRegister(BreakoutAnalogIO.CH00INRANGE, (uint)InputRange0);
+                device.WriteRegister(BreakoutAnalogIO.CH01INRANGE, (uint)InputRange1);
+                device.WriteRegister(BreakoutAnalogIO.CH02INRANGE, (uint)InputRange2);
+                device.WriteRegister(BreakoutAnalogIO.CH03INRANGE, (uint)InputRange3);
+                device.WriteRegister(BreakoutAnalogIO.CH04INRANGE, (uint)InputRange4);
+                device.WriteRegister(BreakoutAnalogIO.CH05INRANGE, (uint)InputRange5);
+                device.WriteRegister(BreakoutAnalogIO.CH06INRANGE, (uint)InputRange6);
+                device.WriteRegister(BreakoutAnalogIO.CH07INRANGE, (uint)InputRange7);
+                device.WriteRegister(BreakoutAnalogIO.CH08INRANGE, (uint)InputRange8);
+                device.WriteRegister(BreakoutAnalogIO.CH09INRANGE, (uint)InputRange9);
+                device.WriteRegister(BreakoutAnalogIO.CH10INRANGE, (uint)InputRange10);
+                device.WriteRegister(BreakoutAnalogIO.CH11INRANGE, (uint)InputRange11);
 
                 // Build the whole value for CHDIR and write it once
-                static uint SetIO(uint io_reg, int channel, AnalogIODirection direction) =>
+                static uint SetIO(uint io_reg, int channel, BreakoutAnalogIODirection direction) =>
                     (io_reg & ~((uint)1 << channel)) | ((uint)(direction) << channel);
 
                 var io_reg = 0u;
@@ -151,9 +151,9 @@ namespace OpenEphys.Onix
                 io_reg = SetIO(io_reg, 9, Direction9);
                 io_reg = SetIO(io_reg, 10, Direction10);
                 io_reg = SetIO(io_reg, 11, Direction11);
-                device.WriteRegister(AnalogIO.CHDIR, io_reg);
+                device.WriteRegister(BreakoutAnalogIO.CHDIR, io_reg);
 
-                var deviceInfo = new AnalogIODeviceInfo(device, this);
+                var deviceInfo = new BreakoutAnalogIODeviceInfo(device, this);
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
@@ -164,8 +164,8 @@ namespace OpenEphys.Onix
             {
                 var properties = base.GetProperties(context, value, attributes);
                 var sortedOrder = properties.Cast<PropertyDescriptor>()
-                                            .Where(p => p.PropertyType == typeof(AnalogIOVoltageRange)
-                                                     || p.PropertyType == typeof(AnalogIODirection))
+                                            .Where(p => p.PropertyType == typeof(BreakoutAnalogIOVoltageRange)
+                                                     || p.PropertyType == typeof(BreakoutAnalogIODirection))
                                             .OrderBy(p => p.PropertyType.MetadataToken)
                                             .Select(p => p.Name)
                                             .Prepend(nameof(Enable))
@@ -175,7 +175,7 @@ namespace OpenEphys.Onix
         }
     }
 
-    static class AnalogIO
+    static class BreakoutAnalogIO
     {
         public const int ID = 22;
 
@@ -202,15 +202,15 @@ namespace OpenEphys.Onix
         internal class NameConverter : DeviceNameConverter
         {
             public NameConverter()
-                : base(typeof(AnalogIO))
+                : base(typeof(BreakoutAnalogIO))
             {
             }
         }
     }
 
-    class AnalogIODeviceInfo : DeviceInfo
+    class BreakoutAnalogIODeviceInfo : DeviceInfo
     {
-        public AnalogIODeviceInfo(DeviceContext device, ConfigureAnalogIO deviceFactory)
+        public BreakoutAnalogIODeviceInfo(DeviceContext device, ConfigureBreakoutAnalogIO deviceFactory)
             : base(device, deviceFactory.DeviceType)
         {
             VoltsPerDivision = new[]
@@ -230,13 +230,13 @@ namespace OpenEphys.Onix
             };
         }
 
-        public static float GetVoltsPerDivision(AnalogIOVoltageRange voltageRange)
+        public static float GetVoltsPerDivision(BreakoutAnalogIOVoltageRange voltageRange)
         {
             return voltageRange switch
             {
-                AnalogIOVoltageRange.TenVolts => 20.0f / AnalogIO.NumberOfDivisions,
-                AnalogIOVoltageRange.TwoPointFiveVolts => 5.0f / AnalogIO.NumberOfDivisions,
-                AnalogIOVoltageRange.FiveVolts => 10.0f / AnalogIO.NumberOfDivisions,
+                BreakoutAnalogIOVoltageRange.TenVolts => 20.0f / BreakoutAnalogIO.NumberOfDivisions,
+                BreakoutAnalogIOVoltageRange.TwoPointFiveVolts => 5.0f / BreakoutAnalogIO.NumberOfDivisions,
+                BreakoutAnalogIOVoltageRange.FiveVolts => 10.0f / BreakoutAnalogIO.NumberOfDivisions,
                 _ => throw new ArgumentOutOfRangeException(nameof(voltageRange)),
             };
         }
@@ -244,7 +244,7 @@ namespace OpenEphys.Onix
         public float[] VoltsPerDivision { get; }
     }
 
-    public enum AnalogIOVoltageRange
+    public enum BreakoutAnalogIOVoltageRange
     {
         [Description("+/-10.0 V")]
         TenVolts = 0,
@@ -254,13 +254,13 @@ namespace OpenEphys.Onix
         FiveVolts,
     }
 
-    public enum AnalogIODirection
+    public enum BreakoutAnalogIODirection
     {
         Input = 0,
         Output = 1
     }
 
-    public enum AnalogIODataType
+    public enum BreakoutAnalogIODataType
     {
         S16,
         Volts

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
@@ -9,10 +9,10 @@ namespace OpenEphys.Onix
         public ConfigureHeartbeat Heartbeat { get; set; } = new();
 
         [TypeConverter(typeof(HubDeviceConverter))]
-        public ConfigureAnalogIO AnalogIO { get; set; } = new();
+        public ConfigureBreakoutAnalogIO AnalogIO { get; set; } = new();
 
         [TypeConverter(typeof(HubDeviceConverter))]
-        public ConfigureDigitalIO DigitalIO { get; set; } = new();
+        public ConfigureBreakoutDigitalIO DigitalIO { get; set; } = new();
 
         [TypeConverter(typeof(HubDeviceConverter))]
         public ConfigureMemoryMonitor MemoryMonitor { get; set; } = new();

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutDigitalIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutDigitalIO.cs
@@ -3,10 +3,10 @@ using System.ComponentModel;
 
 namespace OpenEphys.Onix
 {
-    public class ConfigureDigitalIO : SingleDeviceFactory
+    public class ConfigureBreakoutDigitalIO : SingleDeviceFactory
     {
-        public ConfigureDigitalIO()
-            : base(typeof(DigitalIO))
+        public ConfigureBreakoutDigitalIO()
+            : base(typeof(BreakoutDigitalIO))
         {
             DeviceAddress = 7;
         }
@@ -22,13 +22,13 @@ namespace OpenEphys.Onix
             return source.ConfigureDevice(context =>
             {
                 var device = context.GetDeviceContext(deviceAddress, DeviceType);
-                device.WriteRegister(DigitalIO.ENABLE, Enable ? 1u : 0);
+                device.WriteRegister(BreakoutDigitalIO.ENABLE, Enable ? 1u : 0);
                 return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
             });
         }
     }
 
-    static class DigitalIO
+    static class BreakoutDigitalIO
     {
         public const int ID = 18;
 
@@ -38,14 +38,14 @@ namespace OpenEphys.Onix
         internal class NameConverter : DeviceNameConverter
         {
             public NameConverter()
-                : base(typeof(DigitalIO))
+                : base(typeof(BreakoutDigitalIO))
             {
             }
         }
     }
 
     [Flags]
-    public enum DigitalPortState : ushort
+    public enum BreakoutDigitalPortState : ushort
     {
         Pin0 = 0x1,
         Pin1 = 0x2,


### PR DESCRIPTION
To align with ONI device descriptors and physical hardware usage, we are renaming these general device types to reflect their physical instantiation in the FMC host breakout board.

Fixes #160 