### PR TITLE
Remove geometric prefix

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231V1.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231V1.cs
@@ -8,7 +8,7 @@ namespace OpenEphys.Onix
     /// a pair of SteamVR V1 base stations.
     /// </summary>
     /// <remarks>
-    /// This configuration class can be linked to a <see cref="TS4231V1GeometricPositionData"/> instance to stream 3D position data from
+    /// This configuration class can be linked to a <see cref="TS4231V1PositionData"/> instance to stream 3D position data from
     /// light-house receivers when SteamVR V1 base stations have been installed above the arena.
     /// </remarks>
     public class ConfigureTS4231V1 : SingleDeviceFactory

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1Data.cs
@@ -18,7 +18,7 @@ namespace OpenEphys.Onix
     /// The data produced by this class contains individual base station pulse/sweep codes and timing information. These data provide
     /// rapid updates that constrain the possible position of a sensor and therefore can be combined with orientation information
     /// in a downstream predictive model (e.g. Kalman filter) for high-accuracy and robust position tracking. To produce naïve
-    /// position estimates, use the <see cref="TS4231V1GeometricPositionData"/> operator instead of this one.
+    /// position estimates, use the <see cref="TS4231V1PositionData"/> operator instead of this one.
     /// </para>
     /// </remarks>
     public class TS4231V1Data : Source<TS4231V1DataFrame>

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionConverter.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionConverter.cs
@@ -9,13 +9,13 @@ namespace OpenEphys.Onix
 {
     class TS4231V1PulseQueue
     {
-        public Queue<ulong> PulseFrameClock { get; } = new(new ulong[TS4231V1GeometricPositionConverter.ValidPulseSequenceTemplate.Length / 4]);
-        public Queue<ulong> PulseHubClock { get; } = new(new ulong[TS4231V1GeometricPositionConverter.ValidPulseSequenceTemplate.Length / 4]);
-        public Queue<double> PulseWidths { get; } = new(new double[TS4231V1GeometricPositionConverter.ValidPulseSequenceTemplate.Length / 4]);
-        public Queue<bool> PulseParse { get; } = new(new bool[TS4231V1GeometricPositionConverter.ValidPulseSequenceTemplate.Length]);
+        public Queue<ulong> PulseFrameClock { get; } = new(new ulong[TS4231V1PositionConverter.ValidPulseSequenceTemplate.Length / 4]);
+        public Queue<ulong> PulseHubClock { get; } = new(new ulong[TS4231V1PositionConverter.ValidPulseSequenceTemplate.Length / 4]);
+        public Queue<double> PulseWidths { get; } = new(new double[TS4231V1PositionConverter.ValidPulseSequenceTemplate.Length / 4]);
+        public Queue<bool> PulseParse { get; } = new(new bool[TS4231V1PositionConverter.ValidPulseSequenceTemplate.Length]);
     }
 
-    class TS4231V1GeometricPositionConverter
+    class TS4231V1PositionConverter
     {
         const double SweepFrequencyHz = 60;
         readonly double HubClockFrequencyPeriod;
@@ -41,7 +41,7 @@ namespace OpenEphys.Onix
 
         Dictionary<int, TS4231V1PulseQueue> PulseQueues = new();
 
-        public TS4231V1GeometricPositionConverter(uint hubClockFrequencyHz, Point3d baseStation1Origin, Point3d baseStation2Origin)
+        public TS4231V1PositionConverter(uint hubClockFrequencyHz, Point3d baseStation1Origin, Point3d baseStation2Origin)
         {
             HubClockFrequencyPeriod = 1d / hubClockFrequencyHz;
 
@@ -56,7 +56,7 @@ namespace OpenEphys.Onix
             q[2] = new Scalar(baseStation2Origin.Z);
         }
 
-        public unsafe TS4231V1GeometricPositionDataFrame Convert(oni.Frame frame)
+        public unsafe TS4231V1PositionDataFrame Convert(oni.Frame frame)
         {
             var payload = (TS4231V1Payload*)frame.Data.ToPointer();
 
@@ -154,7 +154,7 @@ namespace OpenEphys.Onix
             var q1 = q + x2 * v;
             var position = 0.5 * (p1 + q1);
 
-            return new TS4231V1GeometricPositionDataFrame(
+            return new TS4231V1PositionDataFrame(
                 queues.PulseHubClock.ElementAt(ValidPulseSequenceTemplate.Length / 8),
                 queues.PulseFrameClock.ElementAt(ValidPulseSequenceTemplate.Length / 8),
                 payload->SensorIndex,

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionData.cs
@@ -35,7 +35,7 @@ namespace OpenEphys.Onix
     /// estimates using downstream processing.
     /// </para>
     /// </remarks>
-    public class TS4231V1GeometricPositionData : Source<TS4231V1GeometricPositionDataFrame>
+    public class TS4231V1PositionData : Source<TS4231V1PositionDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(TS4231V1.NameConverter))]
@@ -45,7 +45,7 @@ namespace OpenEphys.Onix
         /// Gets or sets the position of the first base station in arbitrary units.
         /// </summary>
         /// <remarks>
-        /// The units used will determine the units of <see cref="TS4231V1GeometricPositionDataFrame.Position"/> and must match those used in <see cref="Q"/>.
+        /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and must match those used in <see cref="Q"/>.
         /// Typically this value is used to define the origin and remains at (0, 0, 0).
         /// </remarks>
         public Point3d P { get; set; } = new(0, 0, 0);
@@ -54,21 +54,21 @@ namespace OpenEphys.Onix
         /// Gets or sets the position of the first base station in arbitrary units.
         /// </summary>
         /// <remarks>
-        /// The units used will determine the units of <see cref="TS4231V1GeometricPositionDataFrame.Position"/> and must match those used in <see cref="P"/>.
+        /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and must match those used in <see cref="P"/>.
         /// </remarks>
         public Point3d Q { get; set; } = new(1, 0, 0);
 
         /// <summary>
-        /// Generates a sequence of <see cref="TS4231V1GeometricPositionDataFrame"/> objects, each of which contains the 3D position of single photodiode.
+        /// Generates a sequence of <see cref="TS4231V1PositionDataFrame"/> objects, each of which contains the 3D position of single photodiode.
         /// </summary>
-        /// <returns>A sequence of <see cref="TS4231V1GeometricPositionDataFrame"/> objects.</returns>
-        public unsafe override IObservable<TS4231V1GeometricPositionDataFrame> Generate()
+        /// <returns>A sequence of <see cref="TS4231V1PositionDataFrame"/> objects.</returns>
+        public unsafe override IObservable<TS4231V1PositionDataFrame> Generate()
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(
-                deviceInfo => Observable.Create<TS4231V1GeometricPositionDataFrame>(observer =>
+                deviceInfo => Observable.Create<TS4231V1PositionDataFrame>(observer =>
                 {
                     var device = deviceInfo.GetDeviceContext(typeof(TS4231V1));
-                    var pulseConverter = new TS4231V1GeometricPositionConverter(device.Hub.ClockHz, P, Q);
+                    var pulseConverter = new TS4231V1PositionConverter(device.Hub.ClockHz, P, Q);
 
                     var frameObserver = Observer.Create<oni.Frame>(
                         frame =>

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionDataFrame.cs
@@ -10,17 +10,17 @@ namespace OpenEphys.Onix
     /// A sequence of 12 <see cref="oni.Frame"/> objects produced by a single TS4231 sensor are required to
     /// geometrically calculate the position of the sensor's photodiode in 3D space.
     /// </remarks>
-    public class TS4231V1GeometricPositionDataFrame
+    public class TS4231V1PositionDataFrame
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TS4231V1GeometricPositionDataFrame"/> class.
+        /// Initializes a new instance of the <see cref="TS4231V1PositionDataFrame"/> class.
         /// </summary>
         /// <param name="clock">The median <see cref="DataFrame.Clock"/> value of the 12 frames required to construct a single position.</param>
         /// <param name="hubClock">The median <see cref="DataFrame.HubClock"/> value of the 12 frames required to construct a single position.</param>
         /// <param name="sensorIndex">The index of the TS4231 sensor that the 3D position corresponds to.</param>
         /// <param name="position">The 3 dimensional position of the photodiode connected to the TS4231 sensor with units determined by
-        /// <see cref="TS4231V1GeometricPositionData.P"/> and <see cref="TS4231V1GeometricPositionData.Q"/>.</param>
-        public TS4231V1GeometricPositionDataFrame(ulong clock, ulong hubClock, int sensorIndex, Vector3 position)
+        /// <see cref="TS4231V1PositionData.P"/> and <see cref="TS4231V1PositionData.Q"/>.</param>
+        public TS4231V1PositionDataFrame(ulong clock, ulong hubClock, int sensorIndex, Vector3 position)
         {
             Clock = clock;
             HubClock = hubClock;
@@ -41,7 +41,7 @@ namespace OpenEphys.Onix
 
         /// <summary>
         /// Gets rhe 3D position of the photodiode connected to the TS4231[<see cref="SensorIndex"/>] sensor with units determined by
-        /// <see cref="TS4231V1GeometricPositionData.P"/> and <see cref="TS4231V1GeometricPositionData.Q"/>.
+        /// <see cref="TS4231V1PositionData.P"/> and <see cref="TS4231V1PositionData.Q"/>.
         /// </summary>
         public Vector3 Position { get; }
     }


### PR DESCRIPTION
To keep naming simple we are omitting this prefix for all `TS4231V1` position streaming types. In fact, given its structure, `TS4231V1PositionDataFrame` can probably even be reused as-is for other methods in the future, since it simply represents a position of a given sensor relative to a base station, which in itself is method-agnostic.