### PR TITLE
Unify processor architecture and avoid exposing internal implementation classes

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix.Design/OpenEphys.Onix.Design.csproj
+++ b/OpenEphys.Onix/OpenEphys.Onix.Design/OpenEphys.Onix.Design.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net472</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <VersionPrefix>0.1.0</VersionPrefix>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenEphys.Onix/OpenEphys.Onix.Design/OpenEphys.Onix.Design.csproj
+++ b/OpenEphys.Onix/OpenEphys.Onix.Design/OpenEphys.Onix.Design.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\OpenEphys.Onix\OpenEphys.Onix.csproj" />
   </ItemGroup>
 

--- a/OpenEphys.Onix/OpenEphys.Onix.sln
+++ b/OpenEphys.Onix/OpenEphys.Onix.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenEphys.Onix", "OpenEphys.Onix\OpenEphys.Onix.csproj", "{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenEphys.Onix.Design", "OpenEphys.Onix.Design\OpenEphys.Onix.Design.csproj", "{149E86EC-B865-463D-81A8-8290CA7F8871}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenEphys.Onix.Design", "OpenEphys.Onix.Design\OpenEphys.Onix.Design.csproj", "{149E86EC-B865-463D-81A8-8290CA7F8871}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F8644FAC-94E5-4E73-B809-925ABABE35B1}"
 	ProjectSection(SolutionItems) = preProject
@@ -14,38 +14,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
-		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Debug|Any CPU.Build.0 = Debug|x64
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Debug|ARM64.ActiveCfg = Debug|x64
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Debug|ARM64.Build.0 = Debug|x64
 		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Debug|x64.ActiveCfg = Debug|x64
 		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Debug|x64.Build.0 = Debug|x64
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Release|Any CPU.ActiveCfg = Release|x64
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Release|Any CPU.Build.0 = Release|x64
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Release|ARM64.ActiveCfg = Release|ARM64
-		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Release|ARM64.Build.0 = Release|ARM64
 		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Release|x64.ActiveCfg = Release|x64
 		{353B1EBC-F8EB-4D99-8331-9FF15EC17F38}.Release|x64.Build.0 = Release|x64
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|ARM64.ActiveCfg = Debug|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|ARM64.Build.0 = Debug|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|x64.Build.0 = Debug|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|Any CPU.Build.0 = Release|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|ARM64.ActiveCfg = Release|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|ARM64.Build.0 = Release|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|x64.ActiveCfg = Release|Any CPU
-		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|x64.Build.0 = Release|Any CPU
+		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|x64.ActiveCfg = Debug|x64
+		{149E86EC-B865-463D-81A8-8290CA7F8871}.Debug|x64.Build.0 = Debug|x64
+		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|x64.ActiveCfg = Release|x64
+		{149E86EC-B865-463D-81A8-8290CA7F8871}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureFmcLinkController.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace OpenEphys.Onix
 {
-    public abstract class ConfigureFmcLinkController : SingleDeviceFactory
+    internal abstract class ConfigureFmcLinkController : SingleDeviceFactory
     {
         public ConfigureFmcLinkController()
             : base(typeof(FmcLinkController))
@@ -73,20 +73,26 @@ namespace OpenEphys.Onix
                 return DeviceManager.RegisterDevice(deviceName, deviceInfo);
             });
         }
+    }
 
-        internal static class FmcLinkController
-        {
-            public const int ID = 23;
+    internal static class FmcLinkController
+    {
+        public const int ID = 23;
 
-            public const uint ENABLE = 0; // The LSB is used to enable or disable the device data stream
-            public const uint GPOSTATE = 1; // GPO output state (bits 31 downto 3: ignore. bits 2 downto 0: ‘1’ = high, ‘0’ = low)
-            public const uint DESPWR = 2; // Set link deserializer PDB state, 0 = deserializer power off else on. Does not affect port voltage.
-            public const uint PORTVOLTAGE = 3; // 10 * link voltage
-            public const uint SAVEVOLTAGE = 4; // Save link voltage to non-volatile EEPROM if greater than 0. This voltage will be applied after POR.
-            public const uint LINKSTATE = 5; // bit 1 pass; bit 0 lock
+        public const uint ENABLE = 0; // The LSB is used to enable or disable the device data stream
+        public const uint GPOSTATE = 1; // GPO output state (bits 31 downto 3: ignore. bits 2 downto 0: ‘1’ = high, ‘0’ = low)
+        public const uint DESPWR = 2; // Set link deserializer PDB state, 0 = deserializer power off else on. Does not affect port voltage.
+        public const uint PORTVOLTAGE = 3; // 10 * link voltage
+        public const uint SAVEVOLTAGE = 4; // Save link voltage to non-volatile EEPROM if greater than 0. This voltage will be applied after POR.
+        public const uint LINKSTATE = 5; // bit 1 pass; bit 0 lock
 
-            public const uint LINKSTATE_PP = 0x2; // parity check pass bit
-            public const uint LINKSTATE_SL = 0x1; // SERDES lock bit
-        }
+        public const uint LINKSTATE_PP = 0x2; // parity check pass bit
+        public const uint LINKSTATE_SL = 0x1; // SERDES lock bit
+    }
+
+    internal enum HubConfiguration
+    {
+        Standard,
+        Passthrough
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/DS90UB9x.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DS90UB9x.cs
@@ -1,33 +1,5 @@
-﻿using System;
-using System.ComponentModel;
-
-namespace OpenEphys.Onix
+﻿namespace OpenEphys.Onix
 {
-    public class ConfigureDS90UB9x : SingleDeviceFactory
-    {
-        public ConfigureDS90UB9x()
-            : base(typeof(DS90UB9x))
-        {
-        }
-
-        [Category(ConfigurationCategory)]
-        [Description("Specifies whether the DS90UB9x raw device is enabled.")]
-        public bool Enable { get; set; } = true;
-
-        public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
-        {
-            var enable = Enable;
-            var deviceName = DeviceName;
-            var deviceAddress = DeviceAddress;
-            return source.ConfigureDevice(context =>
-            {
-                var device = context.GetDeviceContext(deviceAddress, DeviceType);
-                device.WriteRegister(DS90UB9x.ENABLE, enable ? 1u : 0);
-                return DeviceManager.RegisterDevice(deviceName, device, DeviceType);
-            });
-        }
-    }
-
     static class DS90UB9x
     {
         public const int ID = 24;

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceContext.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceContext.cs
@@ -2,7 +2,7 @@
 
 namespace OpenEphys.Onix
 {
-    public class DeviceContext
+    internal class DeviceContext
     {
         readonly ContextTask _context;
         readonly oni.Device _device;

--- a/OpenEphys.Onix/OpenEphys.Onix/HubConfiguration.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HubConfiguration.cs
@@ -1,8 +1,0 @@
-﻿namespace OpenEphys.Onix
-{
-    public enum HubConfiguration
-    {
-        Standard,
-        Passthrough
-    }
-}

--- a/OpenEphys.Onix/OpenEphys.Onix/OpenEphys.Onix.csproj
+++ b/OpenEphys.Onix/OpenEphys.Onix/OpenEphys.Onix.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.8.0" />
-    <PackageReference Include="clroni" Version="6.1.0" />
+    <PackageReference Include="Bonsai.Core" Version="2.8.5" />
+    <PackageReference Include="clroni" Version="6.1.2" />
     <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
 


### PR DESCRIPTION
During reorganization of the project for packaging we noticed that there were a few bits still raising warnings on the compiler, specifically related to mismatched processor architectures. The current version of the package targets 64-bit platforms.

Additionally, we also removed internal undocumented implementation classes from the public API surface. These are all types which, while being important for the internal library architecture, are not currently required outside of the library. Keeping them internal will allow us to change their API surface until such time when we need to make them public (if ever).

Finally, the `ConfigureDS90UB9x` operator was removed since it is not really possible to work with the raw serializer stream directly from the workflow without extensive configuration in code and dedicated data nodes.