### PR TITLE
Add missing documentation and description strings for all public classes

### DIFF
--- a/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Bno055Data.cs
@@ -7,16 +7,18 @@ using Bonsai;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// A class that produces a sequence of 3D orientation measurements produced by a BNO055 9-axis inertial measurement unit.
+    /// A class that generates a sequence of 3D orientation measurements produced by BNO055 9-axis inertial measurement unit.
     /// </summary>
     /// <remarks>
     /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureBno055"/>,
     /// in order to stream 3D orientation data.
     /// </remarks>
+    [Description("Generates a sequence of 3D orientation measurements produced by a BNO055 9-axis inertial measurement unit.")]
     public class Bno055Data : Source<Bno055DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(Bno055.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogInput.cs
@@ -12,10 +12,12 @@ namespace OpenEphys.Onix
     /// <summary>
     /// Produces a sequence of analog input frames from an ONIX breakout board.
     /// </summary>
+    [Description("Produces a sequence of analog input frames from an ONIX breakout board.")]
     public class BreakoutAnalogInput : Source<BreakoutAnalogInputDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(BreakoutAnalogIO.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutAnalogOutput.cs
@@ -10,12 +10,14 @@ namespace OpenEphys.Onix
     /// <summary>
     /// Sends analog output data to an ONIX breakout board.
     /// </summary>
+    [Description("Sends analog output data to an ONIX breakout board.")]
     public class BreakoutAnalogOutput : Sink<Mat>
     {
         const BreakoutAnalogIOVoltageRange OutputRange = BreakoutAnalogIOVoltageRange.TenVolts;
 
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(BreakoutAnalogIO.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>
@@ -27,6 +29,7 @@ namespace OpenEphys.Onix
         /// When <see cref="BreakoutAnalogIODataType.Volts"/> is selected, 32-bit floating point voltages between -10 and 10 volts are sent
         /// directly to the DACs.
         /// </remarks>
+        [Description("The data type used to represent analog samples.")]
         public BreakoutAnalogIODataType DataType { get; set; } = BreakoutAnalogIODataType.S16;
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalInput.cs
@@ -7,16 +7,18 @@ using Bonsai;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// A class that produces a sequence of digital input data frames.
+    /// A class that produces a sequence of digital input frames from an ONIX breakout board.
     /// </summary>
     /// <remarks>
     /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureBreakoutDigitalIO"/>,
     /// in order to stream data.
     /// </remarks>
+    [Description("Produces a sequence of digital input frames from an ONIX breakout board.")]
     public class BreakoutDigitalInput : Source<BreakoutDigitalInputDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(BreakoutDigitalIO.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalOutput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/BreakoutDigitalOutput.cs
@@ -9,10 +9,12 @@ namespace OpenEphys.Onix
     /// <summary>
     /// Sends digital output data to an ONIX breakout board.
     /// </summary>
+    [Description("Sends digital output data to an ONIX breakout board.")]
     public class BreakoutDigitalOutput : Sink<BreakoutDigitalPortState>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(BreakoutDigitalIO.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBno055.cs
@@ -9,6 +9,7 @@ namespace OpenEphys.Onix
     /// <remarks>
     /// This configuration class can be linked to a <see cref="Bno055Data"/> instance to stream orientation data from the IMU.
     /// </remarks>
+    [Description("Configures a Bosch BNO055 9-axis IMU device.")]
     public class ConfigureBno055 : SingleDeviceFactory
     {
         /// <summary>
@@ -20,7 +21,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the device enable state.
+        /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
         /// If set to true, a <see cref="Bno055Data"/> instance that is linked to this configuration will produce data. If set to false,
@@ -31,7 +32,7 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         /// <summary>
-        /// Configure a BNO055 device.
+        /// Configures a Bosch BNO055 9-axis IMU device.
         /// </summary>
         /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutAnalogIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutAnalogIO.cs
@@ -8,6 +8,7 @@ namespace OpenEphys.Onix
     /// A class for configuring the ONIX breakout board's analog inputs and outputs.
     /// </summary>
     [TypeConverter(typeof(SortedPropertyConverter))]
+    [Description("Configures the analog input and output device in the ONIX breakout board.")]
     public class ConfigureBreakoutAnalogIO : SingleDeviceFactory
     {
         /// <summary>
@@ -20,7 +21,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the device enable state.
+        /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
         /// If set to true, <see cref="BreakoutAnalogInput"/> will produce data. If set to false, <see cref="BreakoutAnalogInput"/> will not produce data.
@@ -30,185 +31,186 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         /// <summary>
-        /// Get or set the input voltage range of channel 0.
+        /// Gets or sets the input voltage range of channel 0.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 0.")]
         public BreakoutAnalogIOVoltageRange InputRange0 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 1.
+        /// Gets or sets the input voltage range of channel 1.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 1.")]
         public BreakoutAnalogIOVoltageRange InputRange1 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 2.
+        /// Gets or sets the input voltage range of channel 2.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 2.")]
         public BreakoutAnalogIOVoltageRange InputRange2 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 3.
+        /// Gets or sets the input voltage range of channel 3.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 3.")]
         public BreakoutAnalogIOVoltageRange InputRange3 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 4.
+        /// Gets or sets the input voltage range of channel 4.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 4.")]
         public BreakoutAnalogIOVoltageRange InputRange4 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 5.
+        /// Gets or sets the input voltage range of channel 5.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 5.")]
         public BreakoutAnalogIOVoltageRange InputRange5 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 6.
+        /// Gets or sets the input voltage range of channel 6.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 6.")]
         public BreakoutAnalogIOVoltageRange InputRange6 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 7.
+        /// Gets or sets the input voltage range of channel 7.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 7.")]
         public BreakoutAnalogIOVoltageRange InputRange7 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 8.
+        /// Gets or sets the input voltage range of channel 8.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 8.")]
         public BreakoutAnalogIOVoltageRange InputRange8 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 9.
+        /// Gets or sets the input voltage range of channel 9.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 9.")]
         public BreakoutAnalogIOVoltageRange InputRange9 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 10.
+        /// Gets or sets the input voltage range of channel 10.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 10.")]
         public BreakoutAnalogIOVoltageRange InputRange10 { get; set; }
 
         /// <summary>
-        /// Get or set the input voltage range of channel 11.
+        /// Gets or sets the input voltage range of channel 11.
         /// </summary>
         [Category(ConfigurationCategory)]
         [Description("The input voltage range of channel 11.")]
         public BreakoutAnalogIOVoltageRange InputRange11 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 0.
+        /// Gets or sets the direction of channel 0.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 0.")]
         public BreakoutAnalogIODirection Direction0 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 1.
+        /// Gets or sets the direction of channel 1.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 1.")]
         public BreakoutAnalogIODirection Direction1 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 2.
+        /// Gets or sets the direction of channel 2.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 2.")]
         public BreakoutAnalogIODirection Direction2 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 3.
+        /// Gets or sets the direction of channel 3.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 3.")]
         public BreakoutAnalogIODirection Direction3 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 4.
+        /// Gets or sets the direction of channel 4.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 4.")]
         public BreakoutAnalogIODirection Direction4 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 5.
+        /// Gets or sets the direction of channel 5.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 5.")]
         public BreakoutAnalogIODirection Direction5 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 6.
+        /// Gets or sets the direction of channel 6.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 6.")]
         public BreakoutAnalogIODirection Direction6 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 7.
+        /// Gets or sets the direction of channel 7.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 7.")]
         public BreakoutAnalogIODirection Direction7 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 8.
+        /// Gets or sets the direction of channel 8.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 8.")]
         public BreakoutAnalogIODirection Direction8 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 9.
+        /// Gets or sets the direction of channel 9.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 9.")]
         public BreakoutAnalogIODirection Direction9 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 10.
+        /// Gets or sets the direction of channel 10.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 10.")]
         public BreakoutAnalogIODirection Direction10 { get; set; }
 
         /// <summary>
-        /// Get or set the direction of channel 11.
+        /// Gets or sets the direction of channel 11.
         /// </summary>
         [Category(AcquisitionCategory)]
         [Description("The direction of channel 11.")]
         public BreakoutAnalogIODirection Direction11 { get; set; }
 
         /// <summary>
-        /// Configure analog inputs and outputs within an ONI context.
+        /// Configures the analog input and output device in the ONIX breakout board.
         /// </summary>
         /// <remarks>
-        /// This will schedule analog IO hardware configuration actions that can be applied by a <see cref="StartAcquisition"/> object prior to data collection.
+        /// This will schedule analog IO hardware configuration actions that can be applied by a
+        /// <see cref="StartAcquisition"/> object prior to data collection.
         /// </remarks>
         /// <param name="source">
         /// The sequence of <see cref="ContextTask"/> objects on which to apply the analog IO configuration.
         /// </param>
         /// <returns>
-        /// A sequence of <see cref="ContextTask"/> objects that is identical to <paramref name="source"/> in which each <see cref="ContextTask"/> has been instructed
-        /// to apply the analog IO configuration.
+        /// A sequence of <see cref="ContextTask"/> objects that is identical to <paramref name="source"/>
+        /// in which each <see cref="ContextTask"/> has been instructed to apply the analog IO configuration.
         /// </returns>
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutBoard.cs
@@ -6,30 +6,35 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures an ONIX breakout board.
     /// </summary>
+    [Description("Configures an ONIX breakout board.")]
     public class ConfigureBreakoutBoard : HubDeviceFactory
     {
         /// <summary>
         /// Gets or sets the heartbeat configuration.
         /// </summary>
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the heartbeat device in the ONIX breakout board.")]
         public ConfigureHeartbeat Heartbeat { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the breakout board's analog IO configuration.
         /// </summary>
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the analog IO device in the ONIX breakout board.")]
         public ConfigureBreakoutAnalogIO AnalogIO { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the breakout board's digital IO configuration.
         /// </summary>
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the digital IO device in the ONIX breakout board.")]
         public ConfigureBreakoutDigitalIO DigitalIO { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the hardware memory monitor configuration.
         /// </summary>
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the memory monitor device in the ONIX breakout board.")]
         public ConfigureMemoryMonitor MemoryMonitor { get; set; } = new();
 
         internal override IEnumerable<IDeviceConfiguration> GetDevices()

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutDigitalIO.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureBreakoutDigitalIO.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class for configuring the ONIX breakout board's digital inputs and outputs.
     /// </summary>
+    [Description("Configures the digital input and output device in the ONIX breakout board.")]
     public class ConfigureBreakoutDigitalIO : SingleDeviceFactory
     {
         /// <summary>
@@ -18,7 +19,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the device enable state.
+        /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
         /// If set to true, <see cref="BreakoutDigitalInput"/> will produce data. If set to false, <see cref="BreakoutDigitalInput"/> will not produce data.
@@ -28,13 +29,16 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         /// <summary>
-        /// Configure an ONIX breakout board's digital inputs and outputs within an ONI context.
+        /// Configures the digital input and output device in the ONIX breakout board.
         /// </summary>
         /// <remarks>
-        /// This will schedule digital IO hardware configuration actions that can be applied by a <see cref="StartAcquisition"/> object prior to data collection.
+        /// This will schedule digital IO hardware configuration actions that can be applied by a
+        /// <see cref="StartAcquisition"/> object prior to data collection.
         /// </remarks>
-        /// <param name="source">A sequence of <see cref="ContextTask"/> instances that holds configuration actions.</param>
-        /// <returns>The original sequence modified by adding additional configuration actions required to configure a digital IO device./></returns>
+        /// <param name="source">A sequence of <see cref="ContextTask"/> instances that hold configuration actions.</param>
+        /// <returns>
+        /// The original sequence modified by adding additional configuration actions required to configure a digital IO device.
+        /// </returns>
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
             var deviceName = DeviceName;

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
@@ -9,7 +9,7 @@ namespace OpenEphys.Onix
     /// <remarks>
     /// Harp is a standard for asynchronous real-time data acquisition and experimental
     /// control in neuroscience. It includes a clock synchronization protocol which allows
-    /// Harp devices to be connected to a shared clock line and continuously self-synchronise
+    /// Harp devices to be connected to a shared clock line and continuously self-synchronize
     /// their clocks to a precision of tens of microseconds. This means that all experimental
     /// events are timestamped on the same clock and no post-hoc alignment of timing is necessary.
     /// 

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHarpSyncInput.cs
@@ -3,22 +3,71 @@ using System.ComponentModel;
 
 namespace OpenEphys.Onix
 {
+    /// <summary>
+    /// A class for configuring the ONIX breakout board Harp sync input device.
+    /// </summary>
+    /// <remarks>
+    /// Harp is a standard for asynchronous real-time data acquisition and experimental
+    /// control in neuroscience. It includes a clock synchronization protocol which allows
+    /// Harp devices to be connected to a shared clock line and continuously self-synchronise
+    /// their clocks to a precision of tens of microseconds. This means that all experimental
+    /// events are timestamped on the same clock and no post-hoc alignment of timing is necessary.
+    /// 
+    /// The Harp clock signal is transmitted over a serial line with high precision every second.
+    /// Every time the Harp sync input device in the ONIX breakout board detects a full Harp
+    /// synchronization packet, a new data frame is emitted pairing the current value of the
+    /// Harp clock with the local ONIX acquisition clock.
+    /// 
+    /// Logging the sequence of all Harp synchronization packets can greatly facilitate post-hoc
+    /// analysis and interpretation of timing signals. For more information see
+    /// <see href="https://harp-tech.org/"/>.
+    /// </remarks>
+    [Description("Configures a ONIX breakout board Harp sync input device.")]
     public class ConfigureHarpSyncInput : SingleDeviceFactory
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigureHarpSyncInput"/> class.
+        /// </summary>
         public ConfigureHarpSyncInput()
             : base(typeof(HarpSyncInput))
         {
             DeviceAddress = 12;
         }
 
+        /// <summary>
+        /// Gets or sets a value specifying whether the Harp sync input device is enabled.
+        /// </summary>
         [Category(ConfigurationCategory)]
         [Description("Specifies whether the Harp sync input device is enabled.")]
         public bool Enable { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets a value specifying the physical Harp clock input source.
+        /// </summary>
+        /// <remarks>
+        /// In standard ONIX breakout boards, the Harp mini-jack connector on the side of the
+        /// breakout is configured to receive Harp clock synchronization signals.
+        /// 
+        /// In early access versions of the ONIX breakout board, the Harp mini-jack connector is
+        /// configured for output only, so a special adapter is needed to transmit the
+        /// Harp clock synchronization signal to the breakout clock input zero.
+        /// </remarks>
         [Category(ConfigurationCategory)]
         [Description("Specifies the physical Harp clock input source.")]
         public HarpSyncSource Source { get; set; } = HarpSyncSource.Breakout;
 
+        /// <summary>
+        /// Configures a ONIX breakout board Harp sync input device.
+        /// </summary>
+        /// <remarks>
+        /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance
+        /// prior to data acquisition.
+        /// </remarks>
+        /// <param name="source">A sequence of <see cref="ContextTask"/> instances that hold configuration actions.</param>
+        /// <returns>
+        /// The original sequence modified by adding additional configuration actions required to configure
+        /// a ONIX breakout board Harp sync input device.
+        /// </returns>
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
             var deviceName = DeviceName;
@@ -50,9 +99,22 @@ namespace OpenEphys.Onix
         }
     }
 
+    /// <summary>
+    /// Specifies the physical Harp clock input source.
+    /// </summary>
     public enum HarpSyncSource
     {
+        /// <summary>
+        /// In standard ONIX breakout boards, the Harp mini-jack connector on the side of the
+        /// breakout is configured to receive Harp clock synchronization signals.
+        /// </summary>
         Breakout = 0,
+
+        /// <summary>
+        /// In early access versions of the ONIX breakout board, the Harp mini-jack connector is
+        /// configured for output only, so a special adapter is needed to transmit the
+        /// Harp clock synchronization signal to the breakout clock input zero.
+        /// </summary>
         ClockAdapter = 1
     }
 }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64.cs
@@ -5,8 +5,9 @@ using System.Threading;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// A class that configures ONIX headstage-64.
+    /// A class that configures an ONIX headstage-64 in the specified port.
     /// </summary>
+    [Description("Configures an ONIX headstage-64 in the specified port.")]
     public class ConfigureHeadstage64 : HubDeviceFactory
     {
         PortName port;
@@ -42,6 +43,7 @@ namespace OpenEphys.Onix
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the Rhd2164 device in the headstage-64.")]
         public ConfigureRhd2164 Rhd2164 { get; set; } = new();
 
         /// <summary>
@@ -49,6 +51,7 @@ namespace OpenEphys.Onix
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the Bno055 device in the headstage-64.")]
         public ConfigureBno055 Bno055 { get; set; } = new();
 
         /// <summary>
@@ -56,6 +59,7 @@ namespace OpenEphys.Onix
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the TS4231 device in the headstage-64.")]
         public ConfigureTS4231V1 TS4231 { get; set; } = new() { Enable = false };
 
         /// <summary>
@@ -63,6 +67,7 @@ namespace OpenEphys.Onix
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the ElectricalStimulator device in the headstage-64.")]
         public ConfigureHeadstage64ElectricalStimulator ElectricalStimulator { get; set; } = new();
 
         /// <summary>
@@ -70,6 +75,7 @@ namespace OpenEphys.Onix
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the OpticalStimulator device in the headstage-64.")]
         public ConfigureHeadstage64OpticalStimulator OpticalStimulator { get; set; } = new();
 
         /// <summary>
@@ -78,6 +84,7 @@ namespace OpenEphys.Onix
         /// <remarks>
         /// The port is the physical connection to the ONIX breakout board and must be specified prior to operation.
         /// </remarks>
+        [Description("Specifies the physical connection of the headstage to the ONIX breakout board.")]
         public PortName Port
         {
             get { return port; }
@@ -95,7 +102,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the port voltage override.
+        /// Gets or sets the port voltage override.
         /// </summary>
         /// <remarks>
         /// <para>

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64ElectricalStimulator.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64ElectricalStimulator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace OpenEphys.Onix
 {
@@ -10,6 +11,7 @@ namespace OpenEphys.Onix
     /// current controlled electrical micro-stimulation through a contact on the probe connector on the bottom of the headstage
     /// or the corresponding contact on a compatible electrode interface board.
     /// </remarks>
+    [Description("Configures a headstage-64 onboard electrical stimulator.")]
     public class ConfigureHeadstage64ElectricalStimulator : SingleDeviceFactory
     {
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64OpticalStimulator.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeadstage64OpticalStimulator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace OpenEphys.Onix
 {
@@ -10,6 +11,7 @@ namespace OpenEphys.Onix
     /// through laser diodes or LEDs connected to two contacts on the probe connector on the bottom of the headstage
     /// or the corresponding contacts on a compatible electrode interface board.
     /// </remarks>
+    [Description("Configures a headstage-64 dual-channel optical stimulator.")]
     public class ConfigureHeadstage64OpticalStimulator : SingleDeviceFactory
     {
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureHeartbeat.cs
@@ -13,6 +13,7 @@ namespace OpenEphys.Onix
     /// heartbeats from the acquisition system.
     /// </remarks>
     /// </summary>
+    [Description("Configures a heartbeat device.")]
     public class ConfigureHeartbeat : SingleDeviceFactory
     {
         readonly BehaviorSubject<uint> beatsPerSecond = new(10);
@@ -26,7 +27,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the device enable state.
+        /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
         /// If set to true, a <see cref="HeartbeatData"/> instance that is linked to this configuration will produce data.
@@ -37,7 +38,7 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         /// <summary>
-        /// Get or set the rate at which beats are produced in Hz.
+        /// Gets or sets the rate at which beats are produced in Hz.
         /// </summary>
         /// <remarks>
         /// If set to true, a <see cref="HeartbeatData"/> instance that is linked to this configuration will produce data.
@@ -53,7 +54,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Configure a heartbeat device.
+        /// Configures a heartbeat device.
         /// </summary>
         /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureLoadTester.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureLoadTester.cs
@@ -7,29 +7,52 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
+    /// <summary>
+    /// A class for configuring a load testing device.
+    /// </summary>
+    /// <remarks>
+    /// The load tester device can be configured to produce data at user-settable size and rate
+    /// to stress test various communication links and test closed-loop response latency.
+    /// </remarks>
+    [Description("Configures a load testing device.")]
     public class ConfigureLoadTester : SingleDeviceFactory
     {
         readonly BehaviorSubject<uint> frameHz = new(1000);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigureLoadTester"/> class.
+        /// </summary>
         public ConfigureLoadTester()
             : base(typeof(LoadTester))
         {
         }
 
+        /// <summary>
+        /// Gets or sets a value specifying whether the load testing device is enabled.
+        /// </summary>
         [Category(ConfigurationCategory)]
         [Description("Specifies whether the load testing device is enabled.")]
         public bool Enable { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets the number of repetitions of the 16-bit unsigned integer 42 sent with each read-frame.
+        /// </summary>
         [Category(ConfigurationCategory)]
         [Description("Number of repetitions of the 16-bit unsigned integer 42 sent with each read-frame.")]
         [Range(0, 10e6)]
         public uint ReceivedWords { get; set; }
 
+        /// <summary>
+        /// Gets or sets the number of repetitions of the 32-bit integer 42 sent with each write frame.
+        /// </summary>
         [Category(ConfigurationCategory)]
         [Description("Number of repetitions of the 32-bit integer 42 sent with each write frame.")]
         [Range(0, 10e6)]
         public uint TransmittedWords { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value specifying the rate at which frames are produced, in Hz.
+        /// </summary>
         [Category(AcquisitionCategory)]
         [Description("Specifies the rate at which frames are produced (Hz).")]
         public uint FramesPerSecond
@@ -38,6 +61,18 @@ namespace OpenEphys.Onix
             set { frameHz.OnNext(value); }
         }
 
+        /// <summary>
+        /// Configures a load testing device.
+        /// </summary>
+        /// <remarks>
+        /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance
+        /// prior to data acquisition.
+        /// </remarks>
+        /// <param name="source">A sequence of <see cref="ContextTask"/> instances that hold configuration actions.</param>
+        /// <returns>
+        /// The original sequence modified by adding additional configuration actions required to configure
+        /// a load testing device.
+        /// </returns>
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
             var enable = Enable;

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureMemoryMonitor.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureMemoryMonitor.cs
@@ -5,7 +5,7 @@ using Bonsai;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// A class for configuring a hardware memory monitor.
+    /// A class for configuring a hardware memory monitor device.
     /// </summary>
     /// <remarks>
     /// The memory monitor produces periodic snapshots of the system's first in, first out (FIFO) data buffer.
@@ -20,6 +20,7 @@ namespace OpenEphys.Onix
     /// bandwidth of data being acquired, the performance of the host PC, and downstream real-time processing.</description></item>
     /// </list>
     /// </remarks>
+    [Description("Configures a hardware memory monitor device.")]
     public class ConfigureMemoryMonitor : SingleDeviceFactory
     {
         /// <summary>
@@ -32,7 +33,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the device enable state.
+        /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
         /// If set to true, <see cref="MemoryMonitorData"/> will produce data. If set to false, <see cref="MemoryMonitorData"/> will not produce data.
@@ -42,7 +43,7 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = false;
 
         /// <summary>
-        /// Get or set the frequency at which memory use is recorded in Hz.
+        /// Gets or sets the frequency at which memory use is recorded in Hz.
         /// </summary>
         [Range(1, 1000)]
         [Category(ConfigurationCategory)]
@@ -50,7 +51,7 @@ namespace OpenEphys.Onix
         public uint SamplesPerSecond { get; set; } = 10;
 
         /// <summary>
-        /// Configure a memory monitor device.
+        /// Configures a memory monitor device.
         /// </summary>
         /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1e.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1e.cs
@@ -9,6 +9,7 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures a NeuropixelsV1e device.
     /// </summary>
+    [Description("Configures a NeuropixelsV1e device.")]
     public class ConfigureNeuropixelsV1e : SingleDeviceFactory
     {
         /// <summary>
@@ -110,9 +111,12 @@ namespace OpenEphys.Onix
         public string AdcCalibrationFile { get; set; }
 
         /// <summary>
+        /// Configures a NeuropixelsV1e device.
+        /// </summary>
+        /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> node
         /// prior to data acquisition.
-        /// </summary>
+        /// </remarks>
         /// <param name="source">A sequence of <see cref="ContextTask"/> that holds all configuration actions.</param>
         /// <returns>
         /// The original sequence with the side effect of an additional configuration action to configure

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1eBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1eBno055.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures a NeuropixelsV1eBno055 device.
     /// </summary>
+    [Description("Configures a NeuropixelsV1eBno055 device.")]
     public class ConfigureNeuropixelsV1eBno055 : SingleDeviceFactory
     {
         /// <summary>
@@ -28,9 +29,12 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         /// <summary>
+        /// Configures a NeuropixelsV1eBno055 device.
+        /// </summary>
+        /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> node
         /// prior to data acquisition.
-        /// </summary>
+        /// </remarks>
         /// <param name="source">A sequence of <see cref="ContextTask"/> that holds all configuration actions.</param>
         /// <returns>
         /// The original sequence with the side effect of an additional configuration action to configure

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1eHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV1eHeadstage.cs
@@ -7,10 +7,11 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures a NeuropixelsV1e headstage.
     /// </summary>
+    [Description("Configures a NeuropixelsV1e headstage.")]
     public class ConfigureNeuropixelsV1eHeadstage : HubDeviceFactory
     {
         PortName port;
-        readonly ConfigureNeuropixelsV1LinkController LinkController = new();
+        readonly ConfigureNeuropixelsV1eLinkController LinkController = new();
 
         /// <summary>
         /// Initialize a new instance of a <see cref="ConfigureNeuropixelsV1eHeadstage"/> class.
@@ -22,27 +23,28 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Gets or sets a <see cref="ConfigureNeuropixelsV1e"/> object.
+        /// Gets or sets the NeuropixelsV1e configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
-        [Description("Configure a NeuropixelsV1e device.")]
-        public ConfigureNeuropixelsV1e NeuropixelsV1 { get; set; } = new();
+        [Description("Specifies the configuration for the NeuropixelsV1e device.")]
+        public ConfigureNeuropixelsV1e NeuropixelsV1e { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets a <see cref="ConfigureNeuropixelsV1eBno055"/> object.
+        /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
-        [Description("Configure a NeuropixelsV1eBno055 device.")]
+        [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigureNeuropixelsV1eBno055 Bno055 { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets the <see cref="PortName"/>.
+        /// Gets or sets the port.
         /// </summary>
         /// <remarks>
-        /// The port is the physical connection on the breakout board.
+        /// The port is the physical connection to the ONIX breakout board and must be specified prior to operation.
         /// </remarks>
+        [Description("Specifies the physical connection of the headstage to the ONIX breakout board.")]
         public PortName Port
         {
             get { return port; }
@@ -51,7 +53,7 @@ namespace OpenEphys.Onix
                 port = value;
                 var offset = (uint)port << 8;
                 LinkController.DeviceAddress = (uint)port;
-                NeuropixelsV1.DeviceAddress = offset + 0;
+                NeuropixelsV1e.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
         }
@@ -77,11 +79,11 @@ namespace OpenEphys.Onix
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return LinkController;
-            yield return NeuropixelsV1;
+            yield return NeuropixelsV1e;
             yield return Bno055;
         }
 
-        class ConfigureNeuropixelsV1LinkController : ConfigureFmcLinkController
+        class ConfigureNeuropixelsV1eLinkController : ConfigureFmcLinkController
         {
             protected override bool ConfigurePortVoltage(DeviceContext device)
             {

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2e.cs
@@ -8,6 +8,7 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures a NeuropixelsV2e device.
     /// </summary>
+    [Description("Configures a NeuropixelsV2e device.")]
     public class ConfigureNeuropixelsV2e : SingleDeviceFactory
     {
         /// <summary>
@@ -68,9 +69,12 @@ namespace OpenEphys.Onix
         public string GainCalibrationFileB { get; set; }
 
         /// <summary>
+        /// Configures a NeuropixelsV2e device.
+        /// </summary>
+        /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> node
         /// prior to data acquisition.
-        /// </summary>
+        /// </remarks>
         /// <param name="source">A sequence of <see cref="ContextTask"/> that holds all configuration actions.</param>
         /// <returns>
         /// The original sequence with the side effect of an additional configuration action to configure

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBeta.cs
@@ -8,6 +8,7 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures a NeuropixelsV2eBeta device.
     /// </summary>
+    [Description("Configures a NeuropixelsV2eBeta device.")]
     public class ConfigureNeuropixelsV2eBeta : SingleDeviceFactory
     {
         /// <summary>
@@ -78,7 +79,7 @@ namespace OpenEphys.Onix
         public string GainCalibrationFileB { get; set; }
 
         /// <summary>
-        /// Configure a NeuropixelsV2eBeta device.
+        /// Configures a NeuropixelsV2eBeta device.
         /// </summary>
         /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBetaHeadstage.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures a NeuropixelsV2eBeta headstage.
     /// </summary>
+    [Description("Configures a NeuropixelsV2eBeta headstage.")]
     public class ConfigureNeuropixelsV2eBetaHeadstage : HubDeviceFactory
     {
         PortName port;
@@ -21,25 +22,28 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Gets or sets a <see cref="ConfigureNeuropixelsV2eBeta"/> object.
+        /// Gets or sets the NeuropixelsV2eBeta configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
-        public ConfigureNeuropixelsV2eBeta NeuropixelsV2Beta { get; set; } = new();
+        [Description("Specifies the configuration for the NeuropixelsV2eBeta device.")]
+        public ConfigureNeuropixelsV2eBeta NeuropixelsV2eBeta { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets a <see cref="ConfigureNeuropixelsV2eBno055"/> object.
+        /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
+        [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigureNeuropixelsV2eBno055 Bno055 { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets the <see cref="PortName"/>.
+        /// Gets or sets the port.
         /// </summary>
         /// <remarks>
-        /// The port is the physical connection on the breakout board.
+        /// The port is the physical connection to the ONIX breakout board and must be specified prior to operation.
         /// </remarks>
+        [Description("Specifies the physical connection of the headstage to the ONIX breakout board.")]
         public PortName Port
         {
             get { return port; }
@@ -48,7 +52,7 @@ namespace OpenEphys.Onix
                 port = value;
                 var offset = (uint)port << 8;
                 LinkController.DeviceAddress = (uint)port;
-                NeuropixelsV2Beta.DeviceAddress = offset + 0;
+                NeuropixelsV2eBeta.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
         }
@@ -74,7 +78,7 @@ namespace OpenEphys.Onix
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return LinkController;
-            yield return NeuropixelsV2Beta;
+            yield return NeuropixelsV2eBeta;
             yield return Bno055;
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eBno055.cs
@@ -4,8 +4,9 @@ using System.ComponentModel;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// A class that configures a ConfigureNeuropixelsV2eBno055 device.
+    /// A class that configures a NeuropixelsV2eBno055 device.
     /// </summary>
+    [Description("Configures a NeuropixelsV2eBno055 device.")]
     public class ConfigureNeuropixelsV2eBno055 : SingleDeviceFactory
     {
         /// <summary>
@@ -28,9 +29,12 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         /// <summary>
+        /// Configures a NeuropixelsV2eBno055 device.
+        /// </summary>
+        /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> node
         /// prior to data acquisition.
-        /// </summary>
+        /// </remarks>
         /// <param name="source">A sequence of <see cref="ContextTask"/> that holds all configuration actions.</param>
         /// <returns>
         /// The original sequence with the side effect of an additional configuration action to configure

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureNeuropixelsV2eHeadstage.cs
@@ -6,6 +6,7 @@ namespace OpenEphys.Onix
     /// <summary>
     /// A class that configures a NeuropixelsV2e headstage.
     /// </summary>
+    [Description("configures a NeuropixelsV2e headstage.")]
     public class ConfigureNeuropixelsV2eHeadstage : HubDeviceFactory
     {
         PortName port;
@@ -21,27 +22,28 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Gets or sets a <see cref="ConfigureNeuropixelsV2e"/> object.
+        /// Gets or sets the NeuropixelsV2e configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
-        [Description("Configure a NeuropixelsV2e device.")]
-        public ConfigureNeuropixelsV2e NeuropixelsV2 { get; set; } = new();
+        [Description("Specifies the configuration for the NeuropixelsV2e device.")]
+        public ConfigureNeuropixelsV2e NeuropixelsV2e { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets a <see cref="ConfigureNeuropixelsV2eBno055"/> object.
+        /// Gets or sets the Bno055 9-axis inertial measurement unit configuration.
         /// </summary>
         [Category(ConfigurationCategory)]
         [TypeConverter(typeof(HubDeviceConverter))]
-        [Description("Configure a NeuropixelsV2eBno055 device.")]
+        [Description("Specifies the configuration for the Bno055 device.")]
         public ConfigureNeuropixelsV2eBno055 Bno055 { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets the <see cref="PortName"/>.
+        /// Gets or sets the port.
         /// </summary>
         /// <remarks>
-        /// The port is the physical connection on the breakout board.
+        /// The port is the physical connection to the ONIX breakout board and must be specified prior to operation.
         /// </remarks>
+        [Description("Specifies the physical connection of the headstage to the ONIX breakout board.")]
         public PortName Port
         {
             get { return port; }
@@ -50,7 +52,7 @@ namespace OpenEphys.Onix
                 port = value;
                 var offset = (uint)port << 8;
                 LinkController.DeviceAddress = (uint)port;
-                NeuropixelsV2.DeviceAddress = offset + 0;
+                NeuropixelsV2e.DeviceAddress = offset + 0;
                 Bno055.DeviceAddress = offset + 1;
             }
         }
@@ -76,7 +78,7 @@ namespace OpenEphys.Onix
         internal override IEnumerable<IDeviceConfiguration> GetDevices()
         {
             yield return LinkController;
-            yield return NeuropixelsV2;
+            yield return NeuropixelsV2e;
             yield return Bno055;
         }
     }

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureRhd2164.cs
@@ -10,6 +10,7 @@ namespace OpenEphys.Onix
     /// This configuration class can be linked to a <see cref="Rhd2164Data"/> instance to stream
     /// electrophysiology data from the chip.
     /// </remarks>
+    [Description("Configures a RHD2164 device.")]
     public class ConfigureRhd2164 : SingleDeviceFactory
     {
         /// <summary>
@@ -21,7 +22,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the device enable state.
+        /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
         /// If set to true, a <see cref="Rhd2164Data"/> instance that is linked to this configuration will produce data.
@@ -53,7 +54,7 @@ namespace OpenEphys.Onix
         public Rhd2164AnalogHighCutoff AnalogHighCutoff { get; set; } = Rhd2164AnalogHighCutoff.High10000Hz;
 
         /// <summary>
-        /// Configure a RHD2164 device.
+        /// Configures a RHD2164 device.
         /// </summary>
         /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance

--- a/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231V1.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ConfigureTS4231V1.cs
@@ -11,6 +11,7 @@ namespace OpenEphys.Onix
     /// This configuration class can be linked to a <see cref="TS4231V1PositionData"/> instance to stream 3D position data from
     /// light-house receivers when SteamVR V1 base stations have been installed above the arena.
     /// </remarks>
+    [Description("Configures a TS4231 receiver array.")]
     public class ConfigureTS4231V1 : SingleDeviceFactory
     {
         /// <summary>
@@ -22,7 +23,7 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Get or set the device enable state.
+        /// Gets or sets the device enable state.
         /// </summary>
         /// <remarks>
         /// If set to true, a <see cref="TS4231V1Data"/> instance that is linked to this configuration will produce data. If set to false,
@@ -33,7 +34,7 @@ namespace OpenEphys.Onix
         public bool Enable { get; set; } = true;
 
         /// <summary>
-        /// Configure a TS4231 receiver array.
+        /// Configures a TS4231 receiver array.
         /// </summary>
         /// <remarks>
         /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -41,7 +41,7 @@ namespace OpenEphys.Onix
         internal const string DefaultDriver = "riffa";
         internal const int DefaultIndex = 0;
 
-        // NB: Decouple OnNext() form hardware reads
+        // NB: Decouple OnNext() from hardware reads
         bool disposed;
         Task readFrames;
         Task distributeFrames;
@@ -390,8 +390,8 @@ namespace OpenEphys.Onix
         /// </summary>
         /// <remarks>
         /// This option allows control over a fundamental trade-off between closed-loop response time and overall bandwidth. 
-        /// A minimal value, which is determined by <see cref="MaxReadFrameSize"/>, will may provide the lowest response latency,
-        /// so long as data can be cleared form hardware memory fast enough to prevent buffering. Larger values will reduce system
+        /// A minimal value, which is determined by <see cref="MaxReadFrameSize"/>, will provide the lowest response latency,
+        /// so long as data can be cleared from hardware memory fast enough to prevent buffering. Larger values will reduce system
         /// call frequency, increase overall bandwidth, and may improve processing performance for high-bandwidth data sources.
         /// The optimal value depends on the host computer and hardware configuration and must be determined via testing (e.g.
         /// using <see cref="MemoryMonitorData"/>).

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -379,7 +379,7 @@ namespace OpenEphys.Onix
         /// </remarks>
         internal bool Running => ctx.Running;
 
-        public int HardwareAddress
+        internal int HardwareAddress
         {
             get => ctx.HardwareAddress;
             set => ctx.HardwareAddress = value;

--- a/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/ContextTask.cs
@@ -68,12 +68,11 @@ namespace OpenEphys.Onix
         /// Initializes a new instance of the <see cref="ContextTask"/> class.
         /// </summary>
         /// <param name="driver"> A string specifying the device driver used to control hardware. </param>
-        /// <param name="index">An index representing the physical location of ONI compliant hardware, to be communicated with using the
-        /// specified  <paramref name="driver"/>, that will be managed by the internal <see cref="oni.Context"/>. For instance, 0 might
+        /// <param name="index">The index of the host interconnect between the ONI controller and host computer. For instance, 0 could
         /// correspond to a particular PCIe slot or USB port as enumerated by the operating system and translated by an
         /// <see href="https://open-ephys.github.io/ONI/api/liboni/driver-translators/index.html#drivers">ONI device driver translator</see>. 
-        /// A value of -1 will attempt to open the default hardware index and is useful if there is only a single ONI controller host
-        /// managed by the specified  <paramref name="driver"/> in the host computer.</param>
+        /// A value of -1 will attempt to open the default hardware index and is useful if there is only a single ONI controller
+        /// managed by the specified <paramref name="driver"/> in the host computer.</param>
         internal ContextTask(string driver, int index)
         {
             groupedFrames = frameReceived.GroupBy(frame => frame.DeviceAddress).Replay();
@@ -387,25 +386,27 @@ namespace OpenEphys.Onix
         }
 
         /// <summary>
-        /// Gets the number of bytes read during each device driver access to the read channel.
+        /// Gets the number of bytes read by the device driver access to the read channel.
         /// </summary>
         /// <remarks>
         /// This option allows control over a fundamental trade-off between closed-loop response time and overall bandwidth. 
-        /// A minimal value (<see cref="MaxReadFrameSize"/>) will generally provide the lowest response latency. Larger values
-        /// will reduce system call frequency and may improve processing performance for high-bandwidth data sources. 
-        /// The optimal value depends on the host computer and hardware configuration and must be determined via testing.
+        /// A minimal value, which is determined by <see cref="MaxReadFrameSize"/>, will may provide the lowest response latency,
+        /// so long as data can be cleared form hardware memory fast enough to prevent buffering. Larger values will reduce system
+        /// call frequency, increase overall bandwidth, and may improve processing performance for high-bandwidth data sources.
+        /// The optimal value depends on the host computer and hardware configuration and must be determined via testing (e.g.
+        /// using <see cref="MemoryMonitorData"/>).
         /// </remarks>
         public int BlockReadSize => ctx.BlockReadSize;
 
         /// <summary>
-        /// Gets the number of bytes read during each device driver access to the read channel.
+        /// Gets the number of bytes that are pre-allocated for writing data to hardware.
         /// </summary>
         /// <remarks>
-        /// This option allows control over a fundamental trade-off between closed-loop response time and overall bandwidth. 
-        /// A minimal value (<see cref="MaxReadFrameSize"/>) will may provide the lowest response latency, so long as data can be
-        /// cleared form hardware memory fast enough to prevent buffering. Larger values will reduce system call frequency, increase
-        /// overall bandwidth, and may improve processing performance for high-bandwidth data sources. The optimal value depends on
-        /// the host computer and hardware configuration and must be determined via testing (e.g. using <see cref="MemoryMonitorData"/>).
+        /// This value determines the amount of memory pre-allocated for calls to <see cref="oni.Context.Write(uint, IntPtr, int)"/>,
+        /// <see cref="oni.Context.Write{T}(uint, T)"/>, and <see cref="oni.Context.Write{T}(uint, T[])"/>. A larger size will reduce
+        /// the average amount of dynamic memory allocation system calls but increase the cost of each of those calls. The minimum
+        /// size of this option is determined by <see cref="MaxWriteFrameSize"/>. The effect on real-timer performance is not as
+        /// large as that of <see cref="BlockReadSize"/>.
         /// </remarks>
         public int BlockWriteSize => ctx.BlockWriteSize;
 

--- a/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
@@ -6,9 +6,10 @@ using System.Reactive.Linq;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// Produces a sequence of <see cref="ContextTask"/> elements, each of which orchestrate a single ONI-compliant controller.
+    /// Creates a <see cref="ContextTask"/> to orchestrate a single ONI-compliant controller
+    /// using the specified device driver and host interconnect.
     /// </summary>
-    [Description("Produces a sequence of ContextTasks, each of which orchestrate a single ONI-compliant controller.")]
+    [Description("Creates a ContextTask to orchestrate a single ONI-compliant controller using the specified device driver and host interconnect.")]
     [Combinator(MethodName = nameof(Generate))]
     [WorkflowElementCategory(ElementCategory.Source)]
     public class CreateContext
@@ -16,6 +17,7 @@ namespace OpenEphys.Onix
         /// <summary>
         /// Gets or sets a string specifying the device driver used to communicate with hardware.
         /// </summary>
+        [Description("Specifies the device driver used to communicate with hardware.")]
         public string Driver { get; set; } = ContextTask.DefaultDriver;
 
         /// <summary>
@@ -27,12 +29,16 @@ namespace OpenEphys.Onix
         /// A value of -1 will attempt to open the default index and is useful if there is only a single ONI controller
         /// managed by the specified selected <see cref="Driver"/> in the host computer.
         /// </remarks>
+        [Description("The index of the host interconnect between the ONI controller and host computer.")]
         public int Index { get; set; } = ContextTask.DefaultIndex;
 
         /// <summary>
-        /// Produces a sequence of <see cref="ContextTask"/> elements that orchestrate ONI compliant controller.
+        /// Generates a sequence that creates a new <see cref="ContextTask"/> object.
         /// </summary>
-        /// <returns>A sequence of <see cref="ContextTask"/> elements that orchestrate ONI compliant controller.</returns>
+        /// <returns>
+        /// A sequence containing a single instance of the <see cref="ContextTask"/> class. Cancelling the sequence
+        /// will dispose of the created context.
+        /// </returns>
         public IObservable<ContextTask> Generate()
         {
             return Observable.Create<ContextTask>(observer =>

--- a/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/CreateContext.cs
@@ -5,15 +5,34 @@ using System.Reactive.Linq;
 
 namespace OpenEphys.Onix
 {
-    [Description("")]
+    /// <summary>
+    /// Produces a sequence of <see cref="ContextTask"/> elements, each of which orchestrate a single ONI-compliant controller.
+    /// </summary>
+    [Description("Produces a sequence of ContextTasks, each of which orchestrate a single ONI-compliant controller.")]
     [Combinator(MethodName = nameof(Generate))]
     [WorkflowElementCategory(ElementCategory.Source)]
     public class CreateContext
     {
+        /// <summary>
+        /// Gets or sets a string specifying the device driver used to communicate with hardware.
+        /// </summary>
         public string Driver { get; set; } = ContextTask.DefaultDriver;
 
+        /// <summary>
+        /// Gets or sets the index of the host interconnect between the ONI controller and host computer.
+        /// </summary>
+        /// <remarks>
+        /// For instance, 0 could correspond to a particular PCIe slot or USB port as enumerated by the operating system and translated by an
+        /// <see href="https://open-ephys.github.io/ONI/api/liboni/driver-translators/index.html#drivers">ONI device driver translator</see>. 
+        /// A value of -1 will attempt to open the default index and is useful if there is only a single ONI controller
+        /// managed by the specified selected <see cref="Driver"/> in the host computer.
+        /// </remarks>
         public int Index { get; set; } = ContextTask.DefaultIndex;
 
+        /// <summary>
+        /// Produces a sequence of <see cref="ContextTask"/> elements that orchestrate ONI compliant controller.
+        /// </summary>
+        /// <returns>A sequence of <see cref="ContextTask"/> elements that orchestrate ONI compliant controller.</returns>
         public IObservable<ContextTask> Generate()
         {
             return Observable.Create<ContextTask>(observer =>

--- a/OpenEphys.Onix/OpenEphys.Onix/DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DataFrame.cs
@@ -24,7 +24,7 @@
         /// Gets the acquisition clock count.
         /// </summary>
         /// <remarks>
-        /// Acquisition clock count that is synchronous for all frames collected within With an ONI context created using <see cref="CreateContext"/>.
+        /// Acquisition clock count that is synchronous for all frames collected within an ONI context created using <see cref="CreateContext"/>.
         /// The acquisition clock rate is given by <see cref="ContextTask.AcquisitionClockHz"/>. This clock value provides a common, synchronized
         /// time base for all data collected with an single ONI context.
         /// </remarks>

--- a/OpenEphys.Onix/OpenEphys.Onix/DataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DataFrame.cs
@@ -6,7 +6,7 @@
     public abstract class DataFrame
     {
         /// <summary>
-        /// Initializes and new instance of the <see cref="DataFrame"/> class.
+        /// Initializes a new instance of the <see cref="DataFrame"/> class.
         /// </summary>
         /// <param name="clock">System clock count. Generally provided by the underlying <see cref="oni.Frame.Clock"/> value.</param>
         internal DataFrame(ulong clock)

--- a/OpenEphys.Onix/OpenEphys.Onix/DeviceFactory.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/DeviceFactory.cs
@@ -5,6 +5,15 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
+    /// <summary>
+    /// Provides an abstract base class for all device configuration operators.
+    /// </summary>
+    /// <remarks>
+    /// ONI devices usually require a specific sequence of configuration and parameterization
+    /// steps before they can be interacted with. The <see cref="DeviceFactory"/> provides
+    /// a modular abstraction for flexible assembly and sequencing of both single and multi-
+    /// device configuration.
+    /// </remarks>
     public abstract class DeviceFactory : Sink<ContextTask>
     {
         internal const string ConfigurationCategory = "Configuration";
@@ -13,8 +22,21 @@ namespace OpenEphys.Onix
         internal abstract IEnumerable<IDeviceConfiguration> GetDevices();
     }
 
+    /// <summary>
+    /// Provides an abstract base class for configuration operators responsible for
+    /// registering a single device in the context device table.
+    /// </summary>
+    /// <remarks>
+    /// ONI devices usually require a specific sequence of configuration and parameterization
+    /// steps before they can be interacted with. The <see cref="SingleDeviceFactory"/>
+    /// provides a modular abstraction allowing flexible assembly and sequencing of
+    /// of all device-specific configuration code.
+    /// </remarks>
     public abstract class SingleDeviceFactory : DeviceFactory, IDeviceConfiguration
     {
+        internal const string DeviceNameDescription = "The unique device name.";
+        internal const string DeviceAddressDescription = "The device address.";
+
         internal SingleDeviceFactory(Type deviceType)
         {
             DeviceType = deviceType ?? throw new ArgumentNullException(nameof(deviceType));
@@ -28,6 +50,7 @@ namespace OpenEphys.Onix
         /// elements for configuration, control, and data streaming to hardware. This is often a one-to-one
         /// representation of an ONI device, but can also represent abstract ONI device aggregates or virtual devices.
         /// </remarks>
+        [Description(DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>
@@ -37,6 +60,7 @@ namespace OpenEphys.Onix
         /// This address provides a fully-qualified location of a device within the device table. This is often a one-to-one
         /// representation of a ONI address, but can also represent abstract device addresses.
         /// </remarks>
+        [Description(DeviceAddressDescription)]
         public uint DeviceAddress { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputData.cs
@@ -6,11 +6,24 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
+    /// <summary>
+    /// A class that generates a sequence of Harp clock synchronization events produced by
+    /// the Harp sync input device in the ONIX breakout board.
+    /// </summary>
+    /// <inheritdoc cref = "ConfigureHarpSyncInput"/>
+    [Description("Generates a sequence of Harp clock synchronization events produced by the Harp sync input device in the ONIX breakout board.")]
     public class HarpSyncInputData : Source<HarpSyncInputDataFrame>
     {
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(HarpSyncInput.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
+        /// <summary>
+        /// Generates a sequence of <see cref="HarpSyncInputDataFrame"/> objects, each of which contains
+        /// information about a single Harp clock synchronization event.
+        /// </summary>
+        /// <returns>A sequence of <see cref="HarpSyncInputDataFrame"/> objects.</returns>
         public override IObservable<HarpSyncInputDataFrame> Generate()
         {
             return DeviceManager.GetDevice(DeviceName).SelectMany(deviceInfo =>

--- a/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputDataFrame.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HarpSyncInputDataFrame.cs
@@ -2,8 +2,17 @@
 
 namespace OpenEphys.Onix
 {
+    /// <summary>
+    /// A class that contains information about a Harp clock synchronization event.
+    /// </summary>
     public class HarpSyncInputDataFrame : DataFrame
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HarpSyncInputDataFrame"/> class.
+        /// </summary>
+        /// <param name="frame">
+        /// A frame produced by the Harp sync input device of an ONIX breakout board.
+        /// </param>
         public unsafe HarpSyncInputDataFrame(oni.Frame frame)
             : base(frame.Clock)
         {
@@ -12,6 +21,9 @@ namespace OpenEphys.Onix
             HarpTime = payload->HarpTime;
         }
 
+        /// <summary>
+        /// Gets the Harp clock time corresponding to the local acquisition ONIX clock count.
+        /// </summary>
         public uint HarpTime { get; }
     }
 

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64ElectricalStimulatorTrigger.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64ElectricalStimulatorTrigger.cs
@@ -17,6 +17,7 @@ namespace OpenEphys.Onix
     /// This class must be linked to an appropriate configuration, such as a <see cref="ConfigureHeadstage64ElectricalStimulator"/>,
     /// in order to define and deliver electrical stimulation sequences.
     /// </remarks>
+    [Description("Controls a headstage-64 onboard electrical stimulus sequencer.")]
     public class Headstage64ElectricalStimulatorTrigger: Sink<bool>
     {
         readonly BehaviorSubject<bool> enable = new(true);
@@ -35,6 +36,7 @@ namespace OpenEphys.Onix
 
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(Headstage64ElectricalStimulator.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/Headstage64OpticalStimulatorTrigger.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Headstage64OpticalStimulatorTrigger.cs
@@ -17,6 +17,7 @@ namespace OpenEphys.Onix
     /// This class must be linked to an appropriate configuration, such as a <see cref="ConfigureHeadstage64OpticalStimulator"/>,
     /// in order to define and deliver optical stimulation sequences.
     /// </remarks>
+    [Description("Controls a headstage-64 onboard optical stimulus sequencer.")]
     public class Headstage64OpticalStimulatorTrigger : Sink<bool>
     {
         readonly BehaviorSubject<bool> enable = new(true);

--- a/OpenEphys.Onix/OpenEphys.Onix/HeartbeatData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HeartbeatData.cs
@@ -13,10 +13,12 @@ namespace OpenEphys.Onix
     /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureHeartbeat"/>,
     /// in order to stream heartbeat data.
     /// </remarks>
+    [Description("Produces a sequence of heartbeat data frames.")]
     public class HeartbeatData : Source<HeartbeatDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(Heartbeat.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/HubDeviceFactory.cs
@@ -1,20 +1,40 @@
 ﻿using System;
+using System.ComponentModel;
 using Bonsai;
 
 namespace OpenEphys.Onix
 {
+    /// <summary>
+    /// Provides an abstract base class for configuration operators responsible for
+    /// registering all devices in an ONI device aggregate in the context device table.
+    /// </summary>
+    /// <remarks>
+    /// ONI devices are often grouped into multi-device aggregates connected to hubs or
+    /// headstages. These aggregates provide access to multiple devices through hub-specific
+    /// addresses and usually require a specific sequence of configuration steps to determine
+    /// operational port voltages and other link-specific settings.
+    /// 
+    /// These multi-device aggregates are the most common starting point for configuration
+    /// of an ONI system, and the <see cref="HubDeviceFactory"/> provides a modular abstraction
+    /// for flexible assembly and sequencing of multiple such aggregates.
+    /// </remarks>
     public abstract class HubDeviceFactory : DeviceFactory, INamedElement
     {
         const string BaseTypePrefix = "Configure";
         string _name;
 
-        protected HubDeviceFactory()
+        internal HubDeviceFactory()
         {
             var baseName = GetType().Name;
             var prefixIndex = baseName.IndexOf(BaseTypePrefix);
             Name = prefixIndex >= 0 ? baseName.Substring(prefixIndex + BaseTypePrefix.Length) : baseName;
         }
 
+        /// <summary>
+        /// Gets or sets a unique hub device name.
+        /// </summary>
+        /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
+        [Description("The unique hub device name.")]
         public string Name
         {
             get { return _name; }
@@ -38,6 +58,18 @@ namespace OpenEphys.Onix
             }
         }
 
+        /// <summary>
+        /// Configure all the ONI devices in the multi-device aggregate.
+        /// </summary>
+        /// <remarks>
+        /// This will schedule configuration actions to be applied by a <see cref="StartAcquisition"/> instance
+        /// prior to data acquisition.
+        /// </remarks>
+        /// <param name="source">A sequence of <see cref="ContextTask"/> instances that hold configuration actions.</param>
+        /// <returns>
+        /// The original sequence modified by adding additional configuration actions required to configure
+        /// all the ONI devices in the multi-device aggregate.
+        /// </returns>
         public override IObservable<ContextTask> Process(IObservable<ContextTask> source)
         {
             if (string.IsNullOrEmpty(_name))

--- a/OpenEphys.Onix/OpenEphys.Onix/MemoryMonitorData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/MemoryMonitorData.cs
@@ -13,10 +13,12 @@ namespace OpenEphys.Onix
     /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureMemoryMonitor"/>,
     /// in order to stream data.
     /// </remarks>
+    [Description("Produces a sequence of memory usage data frames.")]
     public class MemoryMonitorData : Source<MemoryMonitorDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(MemoryMonitor.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eBno055Data.cs
@@ -7,12 +7,14 @@ using Bonsai;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// Produces a sequence of NeuropixelsV1eBno055 frames from a NeuropixelsV1e headstage.
+    /// Produces a sequence of <see cref="Bno055DataFrame"/> objects from a NeuropixelsV1e headstage.
     /// </summary>
+    [Description("Produces a sequence of Bno055DataFrame objects from a NeuropixelsV1e headstage.")]
     public class NeuropixelsV1eBno055Data : Source<Bno055DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(NeuropixelsV1eBno055.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV1eData.cs
@@ -9,12 +9,14 @@ using OpenCV.Net;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// Produces a sequence of NeuropixelsV1e frames from a NeuropixelsV1e headstage.
+    /// Produces a sequence of <see cref="NeuropixelsV1eDataFrame"/> objects from a NeuropixelsV1e headstage.
     /// </summary>
+    [Description("Produces a sequence of NeuropixelsV1eDataFrame objects from a NeuropixelsV1e headstage.")]
     public class NeuropixelsV1eData : Source<NeuropixelsV1eDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(NeuropixelsV1e.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         int bufferSize = 36;

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBetaData.cs
@@ -9,12 +9,14 @@ using OpenCV.Net;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// Produces a sequence of <see cref="NeuropixelsV2eBetaDataFrame"/> from a NeuropixelsV2eBeta headstage.
+    /// Produces a sequence of <see cref="NeuropixelsV2eBetaDataFrame"/> objects from a NeuropixelsV2eBeta headstage.
     /// </summary>
+    [Description("Produces a sequence of NeuropixelsV2eDataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eBetaData : Source<NeuropixelsV2eBetaDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(NeuropixelsV2eBeta.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>
@@ -23,11 +25,13 @@ namespace OpenEphys.Onix
         /// <remarks>
         /// Buffer size sets the number of frames that are buffered before propagating data.
         /// </remarks>
+        [Description("The number of samples collected for each channel that are used to create a single NeuropixelsV2eBetaDataFrame.")]
         public int BufferSize { get; set; } = 30;
 
         /// <summary>
         /// Gets or sets the probe index.
         /// </summary>
+        [Description("The index of the probe from which to collect sample data")]
         public NeuropixelsV2Probe ProbeIndex { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eBno055Data.cs
@@ -7,12 +7,14 @@ using Bonsai;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// Produces a sequence of <see cref="Bno055DataFrame"/> from a NeuropixelsV2e headstage.
+    /// Produces a sequence of <see cref="Bno055DataFrame"/> objects from a NeuropixelsV2e headstage.
     /// </summary>
+    [Description("Produces a sequence of Bno055DataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eBno055Data : Source<Bno055DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(NeuropixelsV2eBno055.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/NeuropixelsV2eData.cs
@@ -9,12 +9,14 @@ using OpenCV.Net;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// Produces a sequence of <see cref="NeuropixelsV2eDataFrame"/> from a NeuropixelsV2e headstage.
+    /// Produces a sequence of <see cref="NeuropixelsV2eDataFrame"/> objects from a NeuropixelsV2e headstage.
     /// </summary>
+    [Description("Produces a sequence of NeuropixelsV2eDataFrame objects from a NeuropixelsV2e headstage.")]
     public class NeuropixelsV2eData : Source<NeuropixelsV2eDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(NeuropixelsV2e.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>
@@ -26,11 +28,13 @@ namespace OpenEphys.Onix
         /// corresponding clock values, will be collected and packed into each <see cref="NeuropixelsV2eDataFrame"/>. Because channels are 
         /// sampled at 30 kHz, this is equivalent to 1 millisecond of data from each channel.
         /// </remarks>
+        [Description("The number of samples collected for each channel that are used to create a single NeuropixelsV2eDataFrame.")]
         public int BufferSize { get; set; } = 30;
 
         /// <summary>
         /// Gets or sets the probe index.
         /// </summary>
+        [Description("The index of the probe from which to collect sample data")]
         public NeuropixelsV2Probe ProbeIndex { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/Rhd2164Data.cs
@@ -10,16 +10,18 @@ using OpenCV.Net;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// A class that produces a sequence of RHD2164 data frames.
+    /// A class that produces a sequence of <see cref="Rhd2164DataFrame"/> objects.
     /// </summary>
     /// <remarks>
     /// This data stream class must be linked to an appropriate configuration, such as a <see cref="ConfigureRhd2164"/>,
     /// in order to stream electrophysiology data.
     /// </remarks>
+    [Description("produces a sequence of Rhd2164DataFrame objects.")]
     public class Rhd2164Data : Source<Rhd2164DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(Rhd2164.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>
@@ -31,6 +33,7 @@ namespace OpenEphys.Onix
         /// from each of the electrophysiology and auxiliary channels and packed into each <see cref="Rhd2164DataFrame"/>. Because channels are sampled at
         /// 30 kHz, this is equivalent to 1 millisecond of data from each channel.
         /// </remarks>
+        [Description("The number of samples collected for each channel that are used to create a single Rhd2164DataFrame.")]
         public int BufferSize { get; set; } = 30;
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
@@ -17,8 +17,8 @@ namespace OpenEphys.Onix
         /// </summary>
         /// <remarks>
         /// This option allows control over a fundamental trade-off between closed-loop response time and overall bandwidth. 
-        /// A minimal value, which is determined by <see cref="ContextTask.MaxReadFrameSize"/>, will may provide the lowest response latency,
-        /// so long as data can be cleared form hardware memory fast enough to prevent buffering. Larger values will reduce system
+        /// A minimal value, which is determined by <see cref="ContextTask.MaxReadFrameSize"/>, will provide the lowest response latency,
+        /// so long as data can be cleared from hardware memory fast enough to prevent buffering. Larger values will reduce system
         /// call frequency, increase overall bandwidth, and may improve processing performance for high-bandwidth data sources.
         /// The optimal value depends on the host computer and hardware configuration and must be determined via testing (e.g.
         /// using <see cref="MemoryMonitorData"/>).

--- a/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
@@ -5,12 +5,43 @@ using Bonsai;
 
 namespace OpenEphys.Onix
 {
+    /// <summary>
+    /// Starts data acquisition and frame distribution within a given <see cref="ContextTask"/>.
+    /// </summary>
     public class StartAcquisition : Combinator<ContextTask, IGroupedObservable<uint, oni.Frame>>
     {
+        /// <summary>
+        /// Gets or sets the number of bytes read by the device driver access to the read channel.
+        /// </summary>
+        /// <remarks>
+        /// This option allows control over a fundamental trade-off between closed-loop response time and overall bandwidth. 
+        /// A minimal value, which is determined by <see cref="MaxReadFrameSize"/>, will may provide the lowest response latency,
+        /// so long as data can be cleared form hardware memory fast enough to prevent buffering. Larger values will reduce system
+        /// call frequency, increase overall bandwidth, and may improve processing performance for high-bandwidth data sources.
+        /// The optimal value depends on the host computer and hardware configuration and must be determined via testing (e.g.
+        /// using <see cref="MemoryMonitorData"/>).
+        /// </remarks>
         public int ReadSize { get; set; } = 2048;
 
+        /// <summary>
+        /// Gets or sets the number of bytes that are pre-allocated for writing data to hardware.
+        /// </summary>
+        /// <remarks>
+        /// This value determines the amount of memory pre-allocated for calls to <see cref="oni.Context.Write(uint, IntPtr, int)"/>,
+        /// <see cref="oni.Context.Write{T}(uint, T)"/>, and <see cref="oni.Context.Write{T}(uint, T[])"/>. A larger size will reduce
+        /// the average amount of dynamic memory allocation system calls but increase the cost of each of those calls. The minimum
+        /// size of this option is determined by <see cref="MaxWriteFrameSize"/>. The effect on real-timer performance is not as
+        /// large as that of <see cref="BlockReadSize"/>.
+        /// </remarks>
         public int WriteSize { get; set; } = 2048;
 
+        /// <summary>
+        /// Accepts a sequence of <see cref="ContextTask"/> objects and returns a sequence of <see cref="oni.Frame"/> sequences,
+        /// each of which are produced by a single device with one input context task.
+        /// </summary>
+        /// <param name="source">A sequence of <see cref="ContextTask"/> objects.</param>
+        /// <returns>A sequence of <see cref="oni.Frame"/> sequences, each of which are produced by a single device with one input
+        /// <see cref="ContextTask"/>.</returns>
         public override IObservable<IGroupedObservable<uint, oni.Frame>> Process(IObservable<ContextTask> source)
         {
             return source.SelectMany(context =>

--- a/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/StartAcquisition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
 using Bonsai;
@@ -6,8 +7,9 @@ using Bonsai;
 namespace OpenEphys.Onix
 {
     /// <summary>
-    /// Starts data acquisition and frame distribution within a given <see cref="ContextTask"/>.
+    /// Starts data acquisition and frame distribution on a <see cref="ContextTask"/>.
     /// </summary>
+    [Description("Starts data acquisition and frame distribution on a ContextTask.")]
     public class StartAcquisition : Combinator<ContextTask, IGroupedObservable<uint, oni.Frame>>
     {
         /// <summary>
@@ -15,12 +17,13 @@ namespace OpenEphys.Onix
         /// </summary>
         /// <remarks>
         /// This option allows control over a fundamental trade-off between closed-loop response time and overall bandwidth. 
-        /// A minimal value, which is determined by <see cref="MaxReadFrameSize"/>, will may provide the lowest response latency,
+        /// A minimal value, which is determined by <see cref="ContextTask.MaxReadFrameSize"/>, will may provide the lowest response latency,
         /// so long as data can be cleared form hardware memory fast enough to prevent buffering. Larger values will reduce system
         /// call frequency, increase overall bandwidth, and may improve processing performance for high-bandwidth data sources.
         /// The optimal value depends on the host computer and hardware configuration and must be determined via testing (e.g.
         /// using <see cref="MemoryMonitorData"/>).
         /// </remarks>
+        [Description("The number of bytes read by the device driver access to the read channel.")]
         public int ReadSize { get; set; } = 2048;
 
         /// <summary>
@@ -30,18 +33,24 @@ namespace OpenEphys.Onix
         /// This value determines the amount of memory pre-allocated for calls to <see cref="oni.Context.Write(uint, IntPtr, int)"/>,
         /// <see cref="oni.Context.Write{T}(uint, T)"/>, and <see cref="oni.Context.Write{T}(uint, T[])"/>. A larger size will reduce
         /// the average amount of dynamic memory allocation system calls but increase the cost of each of those calls. The minimum
-        /// size of this option is determined by <see cref="MaxWriteFrameSize"/>. The effect on real-timer performance is not as
-        /// large as that of <see cref="BlockReadSize"/>.
+        /// size of this option is determined by <see cref="ContextTask.MaxWriteFrameSize"/>. The effect on real-timer performance is not as
+        /// large as that of <see cref="ContextTask.BlockReadSize"/>.
         /// </remarks>
+        [Description("The number of bytes that are pre-allocated for writing data to hardware.")]
         public int WriteSize { get; set; } = 2048;
 
         /// <summary>
-        /// Accepts a sequence of <see cref="ContextTask"/> objects and returns a sequence of <see cref="oni.Frame"/> sequences,
-        /// each of which are produced by a single device with one input context task.
+        /// Starts data acquisition and frame distribution on a <see cref="ContextTask"/> and returns
+        /// the sequence of all received <see cref="oni.Frame"/> objects, grouped by device address.
         /// </summary>
-        /// <param name="source">A sequence of <see cref="ContextTask"/> objects.</param>
-        /// <returns>A sequence of <see cref="oni.Frame"/> sequences, each of which are produced by a single device with one input
-        /// <see cref="ContextTask"/>.</returns>
+        /// <param name="source">
+        /// The sequence of <see cref="ContextTask"/> objects on which to start data acquisition
+        /// and frame distribution.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="oni.Frame"/> objects for each <see cref="ContextTask"/>,
+        /// grouped by device address.
+        /// </returns>
         public override IObservable<IGroupedObservable<uint, oni.Frame>> Process(IObservable<ContextTask> source)
         {
             return source.SelectMany(context =>

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1Data.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1Data.cs
@@ -21,10 +21,12 @@ namespace OpenEphys.Onix
     /// position estimates, use the <see cref="TS4231V1PositionData"/> operator instead of this one.
     /// </para>
     /// </remarks>
+    [Description("Produces a sequence of decoded optical signals produced by a pair of SteamVR V1 base stations.")]
     public class TS4231V1Data : Source<TS4231V1DataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(TS4231V1.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>

--- a/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionData.cs
+++ b/OpenEphys.Onix/OpenEphys.Onix/TS4231V1PositionData.cs
@@ -35,10 +35,12 @@ namespace OpenEphys.Onix
     /// estimates using downstream processing.
     /// </para>
     /// </remarks>
+    [Description("Produces a sequence of 3D positions from an array of Triad Semiconductor TS4231 receivers beneath a pair of SteamVR V1 base stations.")]
     public class TS4231V1PositionData : Source<TS4231V1PositionDataFrame>
     {
         /// <inheritdoc cref = "SingleDeviceFactory.DeviceName"/>
         [TypeConverter(typeof(TS4231V1.NameConverter))]
+        [Description(SingleDeviceFactory.DeviceNameDescription)]
         public string DeviceName { get; set; }
 
         /// <summary>
@@ -48,14 +50,16 @@ namespace OpenEphys.Onix
         /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and must match those used in <see cref="Q"/>.
         /// Typically this value is used to define the origin and remains at (0, 0, 0).
         /// </remarks>
+        [Description("The position of the first base station in arbitrary units.")]
         public Point3d P { get; set; } = new(0, 0, 0);
 
         /// <summary>
-        /// Gets or sets the position of the first base station in arbitrary units.
+        /// Gets or sets the position of the second base station in arbitrary units.
         /// </summary>
         /// <remarks>
         /// The units used will determine the units of <see cref="TS4231V1PositionDataFrame.Position"/> and must match those used in <see cref="P"/>.
         /// </remarks>
+        [Description("The position of the second base station in arbitrary units.")]
         public Point3d Q { get; set; } = new(1, 0, 0);
 
         /// <summary>


### PR DESCRIPTION
Following #175 this PR completes the technical docs by adding missing documentation comments to all classes and members in the public API surface.

Description attributes were also added to all top-level operator classes to allow displaying summary strings in the toolbox.

Fixes #173 